### PR TITLE
Bugfix/projection

### DIFF
--- a/.run/Torch Debug.run.xml
+++ b/.run/Torch Debug.run.xml
@@ -10,7 +10,6 @@
     <method v="2">
       <option name="Build Solution" enabled="true" />
       <option name="RunConfigurationTask" enabled="true" run_configuration_name="Deploy Server Debug" run_configuration_type="BatchConfigurationType" />
-      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Deploy Client Debug" run_configuration_type="BatchConfigurationType" />
       <option name="RunConfigurationTask" enabled="true" run_configuration_name="Deploy API Test Mod" run_configuration_type="BatchConfigurationType" />
     </method>
   </configuration>

--- a/.run/Torch Release.run.xml
+++ b/.run/Torch Release.run.xml
@@ -10,7 +10,6 @@
     <method v="2">
       <option name="Build Solution" enabled="true" />
       <option name="RunConfigurationTask" enabled="true" run_configuration_name="Deploy Server Release" run_configuration_type="BatchConfigurationType" />
-      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Deploy Client Release" run_configuration_type="BatchConfigurationType" />
       <option name="RunConfigurationTask" enabled="true" run_configuration_name="Deploy API Test Mod" run_configuration_type="BatchConfigurationType" />
     </method>
   </configuration>

--- a/MultigridProjector/Api/BlockState.cs
+++ b/MultigridProjector/Api/BlockState.cs
@@ -15,7 +15,6 @@ namespace MultigridProjector.Api
         BeingBuilt = 4,
 
         // The block has been built to the level required by the blueprint or more
-        // NOTE: Reserved for welder optimization, not used yet. All built blocks remain in BeingBuilt state, currently.
         FullyBuilt = 8,
 
         // There is mismatching block in the place of the projected block with a different definition than required by the blueprint

--- a/MultigridProjector/Api/IMultigridProjectorApi.cs
+++ b/MultigridProjector/Api/IMultigridProjectorApi.cs
@@ -7,7 +7,7 @@ namespace MultigridProjector.Api
 {
     public interface IMultigridProjectorApi
     {
-        // Multigrid Projector version: 0.2.2
+        // Multigrid Projector version: 0.2.3
         string Version { get; }
 
         // Returns the number of subgrids in the active projection, returns zero if there is no projection

--- a/MultigridProjector/Logic/Connection.cs
+++ b/MultigridProjector/Logic/Connection.cs
@@ -7,7 +7,7 @@ namespace MultigridProjector.Logic
     public abstract class Connection<T> where T : MyCubeBlock
     {
         // Corresponding preview block
-        public T Preview;
+        public readonly T Preview;
 
         // Built block if any, null if not built
         public T Block;
@@ -32,7 +32,6 @@ namespace MultigridProjector.Logic
     {
         public BlockLocation TopLocation;
         public bool RequestAttach;
-        public bool IsConnected => HasBuilt && Block.TopBlock != null && !Block.TopBlock.Closed;
 
         public BaseConnection(MyMechanicalConnectionBlockBase previewBlock, BlockLocation topLocation) : base(previewBlock)
         {
@@ -50,7 +49,6 @@ namespace MultigridProjector.Logic
     public class TopConnection: Connection<MyAttachableTopBlockBase>
     {
         public BlockLocation BaseLocation;
-        public bool IsConnected => HasBuilt && Block.Stator != null && !Block.Stator.Closed;
 
         public TopConnection(MyAttachableTopBlockBase previewBlock, BlockLocation baseLocation) : base(previewBlock)
         {

--- a/MultigridProjector/Logic/MultigridProjection.cs
+++ b/MultigridProjector/Logic/MultigridProjection.cs
@@ -465,13 +465,9 @@ namespace MultigridProjector.Logic
             Projector.SetStatsDirty(true);
         }
 
-        // Client only!
         // FIXME: Refactor, simplify
         public void UpdateGridTransformations()
         {
-            if (Projector.Closed || !Clipboard.IsActive)
-                return;
-            
             // Align the preview grids to match any grids has already been built
             
             var projectorMatrix = Projector.WorldMatrix;
@@ -676,7 +672,10 @@ namespace MultigridProjector.Logic
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool IsConnected(BaseConnection baseConnection, TopConnection topConnection)
         {
-            return baseConnection.HasBuilt && topConnection.HasBuilt && baseConnection.Block.TopBlock.EntityId == topConnection.Block.EntityId;
+            return baseConnection.HasBuilt && 
+                   topConnection.HasBuilt && 
+                   baseConnection.Block.TopBlock != null && 
+                   baseConnection.Block.TopBlock.EntityId == topConnection.Block.EntityId;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/MultigridProjector/Logic/MultigridProjection.cs
+++ b/MultigridProjector/Logic/MultigridProjection.cs
@@ -452,12 +452,13 @@ namespace MultigridProjector.Logic
             Projector.SetStatsDirty(true);
         }
 
+        // Client only!
         // FIXME: Refactor, simplify
         public void UpdateGridTransformations()
         {
-            if(Subgrids.Any(s => s.UpdateRequested))
-                ForceUpdateProjection();
-
+            if (Projector.Closed || !Clipboard.IsActive)
+                return;
+            
             var projectorMatrix = Projector.WorldMatrix;
 
             // Apply projections setting (offset, rotation)
@@ -853,6 +854,9 @@ namespace MultigridProjector.Logic
 
             if (_showOnlyBuildable != Projector.GetShowOnlyBuildable())
                 UpdatePreviewBlockVisuals(false);
+            
+            if(Subgrids.Any(s => s.UpdateRequested))
+                ForceUpdateProjection();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/MultigridProjector/Logic/MultigridProjection.cs
+++ b/MultigridProjector/Logic/MultigridProjection.cs
@@ -852,16 +852,14 @@ namespace MultigridProjector.Logic
             }
             else
             {
-                // The request was sent by a client without the plugin installed or from a mod which is not aware of subgrids, but can traverse them.
-                // They send an identityId here, which is very likely above the subgrid count.
-                // Here we attempt to guess the subgrid based on the existence of a weldable block at the given position.
-                // In some cases the result is ambiguous and the first one is picked, but this is still better than not being able to weld at all.
-                // It works for at least the "Build and Repair mod". Do not remove this speculative code, because it fixes compatibility!
-                // It does not work without a mod for hand and ship welders. So a supplemental mod will be needed to send a BuildInternal request.
-                subgrid = Subgrids.Find(sg => sg.HasBuildableBlockAtPosition(previewCubeBlockPosition));
-                if (subgrid == null)
-                    return;
+                // The request was sent by a client without the plugin installed or from a mod which is not aware of subgrids.
+                // They send an identityId value instead of a subgrid index, which is unlikely to be a valid subgrid index.
+                // Allow building only on the first subgrid (main grid).
+                subgrid = Subgrids.First();
             }
+
+            if (!subgrid.HasBuildableBlockAtPosition(previewCubeBlockPosition))
+                return;
 
             var previewGrid = subgrid.PreviewGrid;
             if (previewGrid == null)

--- a/MultigridProjector/Logic/MultigridProjectorApiProvider.cs
+++ b/MultigridProjector/Logic/MultigridProjectorApiProvider.cs
@@ -16,7 +16,7 @@ namespace MultigridProjector.Logic
         private static MultigridProjectorApiProvider _api;
         public static IMultigridProjectorApi Api => _api ?? (_api = new MultigridProjectorApiProvider());
 
-        public string Version => "0.2.2";
+        public string Version => "0.2.3";
 
         public int GetSubgridCount(long projectorId)
         {

--- a/MultigridProjector/Logic/MultigridUpdateWork.cs
+++ b/MultigridProjector/Logic/MultigridUpdateWork.cs
@@ -48,7 +48,7 @@ namespace MultigridProjector.Logic
 
         public void Start()
         {
-            if (!_task.IsComplete) return;
+            if (!IsComplete) return;
 
             _allGridsProcessed = false;
             _task = Parallel.Start(this, OnComplete);

--- a/MultigridProjector/Logic/MultigridUpdateWork.cs
+++ b/MultigridProjector/Logic/MultigridUpdateWork.cs
@@ -106,7 +106,7 @@ namespace MultigridProjector.Logic
                     if(subgrid.TryGetBuiltBlockByPreview(previewBlock, out var builtSlimBlock))
                     {
                         // Already built
-                        blockStates[previewBlock.Position] = BlockState.BeingBuilt;
+                        blockStates[previewBlock.Position] = builtSlimBlock.Integrity >= previewBlock.Integrity ? BlockState.FullyBuilt : BlockState.BeingBuilt;  
                         continue;
                     }
 
@@ -146,6 +146,7 @@ namespace MultigridProjector.Logic
                     switch (blockStates[position])
                     {
                         case BlockState.BeingBuilt:
+                        case BlockState.FullyBuilt:
                             if (baseConnection.Found != null) break;
                             if (subgrid.TryGetBuiltBlockByPreview(baseConnection.Preview.SlimBlock, out var builtBlock))
                                 baseConnection.Found = (MyMechanicalConnectionBlockBase) builtBlock.FatBlock;
@@ -163,6 +164,7 @@ namespace MultigridProjector.Logic
                     switch (blockStates[position])
                     {
                         case BlockState.BeingBuilt:
+                        case BlockState.FullyBuilt:
                             if (topConnection.Found != null) break;
                             if (subgrid.TryGetBuiltBlockByPreview(topConnection.Preview.SlimBlock, out var builtBlock))
                                 topConnection.Found = (MyAttachableTopBlockBase)builtBlock.FatBlock;

--- a/MultigridProjector/Logic/Subgrid.cs
+++ b/MultigridProjector/Logic/Subgrid.cs
@@ -57,7 +57,7 @@ namespace MultigridProjector.Logic
 
         // Welding state statistics collected by the background worker
         public readonly ProjectionStats Stats = new ProjectionStats();
-
+        
         public volatile bool UpdateRequested = true;
 
         public Subgrid(MultigridProjection projection, int index)
@@ -65,7 +65,7 @@ namespace MultigridProjector.Logic
             Index = index;
             GridBuilder = projection.GridBuilders[index];
             PreviewGrid = projection.PreviewGrids[index];
-
+            
             PrepareMechanicalConnections(projection);
             ClearBlockStates();
         }
@@ -401,19 +401,13 @@ namespace MultigridProjector.Logic
                         break;
 
                     case BlockState.Buildable:
+                    case BlockState.Mismatch:
                         ShowCube(projector, slimBlock, true);
                         break;
 
                     case BlockState.BeingBuilt:
-                        HideCube(projector, slimBlock);
-                        break;
-
                     case BlockState.FullyBuilt:
                         HideCube(projector, slimBlock);
-                        break;
-
-                    case BlockState.Mismatch:
-                        ShowCube(projector, slimBlock, false);
                         break;
                 }
 
@@ -460,7 +454,6 @@ namespace MultigridProjector.Logic
                 switch (blockState)
                 {
                     case BlockState.Buildable:
-                        return true;
                     case BlockState.BeingBuilt:
                         return true;
                 }

--- a/MultigridProjector/Logic/Subgrid.cs
+++ b/MultigridProjector/Logic/Subgrid.cs
@@ -451,7 +451,21 @@ namespace MultigridProjector.Logic
         {
             using (BuiltGridLock.Read())
             {
-                return HasBuilt && BlockStates.TryGetValue(position, out var state) && state == BlockState.Buildable;
+                if (!HasBuilt)
+                    return false;
+
+                if (!BlockStates.TryGetValue(position, out var blockState))
+                    return false;
+
+                switch (blockState)
+                {
+                    case BlockState.Buildable:
+                        return true;
+                    case BlockState.BeingBuilt:
+                        return true;
+                }
+
+                return false;
             }
         }
     }

--- a/MultigridProjector/MultigridProjector.projitems
+++ b/MultigridProjector/MultigridProjector.projitems
@@ -58,7 +58,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Logic\ProjectionStats.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Logic\ProjectorSubgrid.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Logic\Subgrid.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Logic\SubgridConnection.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Logic\Connection.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="0Harmony, Version=2.0.4.0, Culture=neutral, PublicKeyToken=null">

--- a/MultigridProjector/Patches/MyMechanicalConnectionBlockBase_RaiseAttachedEntityChanged.cs
+++ b/MultigridProjector/Patches/MyMechanicalConnectionBlockBase_RaiseAttachedEntityChanged.cs
@@ -24,7 +24,7 @@ namespace MultigridProjector.Patches
             {
                 if (!MultigridProjection.TryFindProjectionByBuiltGrid(baseBlock.CubeGrid, out var projection, out _)) return;
 
-                projection.DetectAndUnregisterAnyDisconnectedGrids();
+                projection.ForceUpdateProjection();
             }
             catch (Exception e)
             {

--- a/MultigridProjector/Patches/MyProjectorBase_RemoveProjection.cs
+++ b/MultigridProjector/Patches/MyProjectorBase_RemoveProjection.cs
@@ -35,9 +35,13 @@ namespace MultigridProjector.Patches
                 projector.UpdateText();
                 projector.RaisePropertiesChanged();
 
+                projection.Destroy();
+                
                 if (!keepProjection)
                 {
-                    projection.Destroy();
+                    var clipboard = projection.Clipboard;
+                    clipboard.Deactivate();
+                    clipboard.Clear();
                     projector.SetOriginalGridBuilders(null);
                 }
 

--- a/MultigridProjector/Patches/MyProjectorBase_UpdateAfterSimulation.cs
+++ b/MultigridProjector/Patches/MyProjectorBase_UpdateAfterSimulation.cs
@@ -42,7 +42,8 @@ namespace MultigridProjector.Patches
             if (!MultigridProjection.TryFindProjectionByProjector(projector, out var projection))
             {
                 if (projector == null || projector.Closed || !projector.Enabled || !projector.IsFunctional || 
-                    !projector.AllowWelding || projector.AllowScaling || !projector.Clipboard.IsActive)
+                    !projector.AllowWelding || projector.AllowScaling || !projector.Clipboard.IsActive ||
+                    projector.CubeGrid.IsPreview)
                     return true;
                 
                 var gridBuilders = projector.GetOriginalGridBuilders();

--- a/MultigridProjector/Patches/MyProjectorBase_UpdateAfterSimulation.cs
+++ b/MultigridProjector/Patches/MyProjectorBase_UpdateAfterSimulation.cs
@@ -41,13 +41,19 @@ namespace MultigridProjector.Patches
             // Create the MultigridProjection instance on demand
             if (!MultigridProjection.TryFindProjectionByProjector(projector, out var projection))
             {
-                if (projector == null || projector.Closed || !projector.Enabled || !projector.IsFunctional || 
-                    !projector.AllowWelding || projector.AllowScaling || !projector.Clipboard.IsActive ||
-                    projector.CubeGrid.IsPreview)
+                if (projector == null || 
+                    projector.Closed || 
+                    projector.CubeGrid.IsPreview ||
+                    !projector.Enabled || 
+                    !projector.IsFunctional || 
+                    !projector.AllowWelding || 
+                    projector.AllowScaling || 
+                    projector.Clipboard.PreviewGrids == null || 
+                    projector.Clipboard.PreviewGrids.Count == 0)
                     return true;
                 
                 var gridBuilders = projector.GetOriginalGridBuilders();
-                if (gridBuilders == null || gridBuilders.Count == 0)
+                if (gridBuilders == null || gridBuilders.Count != projector.Clipboard.PreviewGrids.Count)
                     return true;
                     
                 projection = MultigridProjection.Create(projector, gridBuilders);

--- a/MultigridProjector/Patches/MyProjectorBase_UpdateAfterSimulation.cs
+++ b/MultigridProjector/Patches/MyProjectorBase_UpdateAfterSimulation.cs
@@ -102,34 +102,16 @@ namespace MultigridProjector.Patches
             }
 
             var clipboard = projector.GetClipboard();
-            if (!clipboard.IsActive)
-                return false;
-
-            clipboard.Update();
-
-            if (projector.GetShouldResetBuildable())
+            if (clipboard.IsActive)
             {
-                projector.SetShouldResetBuildable(false);
-                foreach (var previewGrid in projection.PreviewGrids)
+                // Client only
+                clipboard.Update();
+                if (projector.GetShouldResetBuildable())
                 {
-                    foreach (var cubeBlock in previewGrid.CubeBlocks)
-                    {
-                        projector.HideCube(cubeBlock);
-                    }
+                    projector.SetShouldResetBuildable(false);
+                    projection.ForceUpdateProjection();
                 }
             }
-
-            if (!projector.GetForceUpdateProjection() && (!projector.GetShouldUpdateProjection() || MySandboxGame.TotalGamePlayTimeInMilliseconds - projector.GetLastUpdate() <= 2000))
-                return false;
-
-            // Call patched UpdateProjection
-            var methodInfo = AccessTools.DeclaredMethod(typeof(MyProjectorBase), "UpdateProjection");
-            methodInfo.Invoke(projector, new object[]{});
-            
-            projector.SetShouldUpdateProjection(false);
-            projector.SetForceUpdateProjection(false);
-            
-            projector.SetLastUpdate(MySandboxGame.TotalGamePlayTimeInMilliseconds);
 
             return false;
         }

--- a/MultigridProjector/Patches/MyProjectorBase_UpdateAfterSimulation.cs
+++ b/MultigridProjector/Patches/MyProjectorBase_UpdateAfterSimulation.cs
@@ -38,9 +38,21 @@ namespace MultigridProjector.Patches
 
         private static bool UpdateAfterSimulation(MyProjectorBase projector, IMyGameLogicComponent gameLogic)
         {
-            // Find the multigrid projection, fall back to the default implementation if this projector is not handled by the plugin
+            // Create the MultigridProjection instance on demand
             if (!MultigridProjection.TryFindProjectionByProjector(projector, out var projection))
-                return true;
+            {
+                if (projector == null || projector.Closed || !projector.Enabled || !projector.IsFunctional || 
+                    !projector.AllowWelding || projector.AllowScaling || !projector.Clipboard.IsActive)
+                    return true;
+                
+                var gridBuilders = projector.GetOriginalGridBuilders();
+                if (gridBuilders == null || gridBuilders.Count == 0)
+                    return true;
+                    
+                projection = MultigridProjection.Create(projector, gridBuilders);
+                if (projection == null)
+                    return true;
+            }
 
             // Call the base class implementation
             //projector.UpdateAfterSimulation();

--- a/MultigridProjector/Patches/MyProjectorClipboard_UpdateGridTransformations.cs
+++ b/MultigridProjector/Patches/MyProjectorClipboard_UpdateGridTransformations.cs
@@ -1,6 +1,5 @@
 using System;
 using HarmonyLib;
-using MultigridProjector.Extensions;
 using MultigridProjector.Logic;
 using MultigridProjector.Utilities;
 using Sandbox.Game.Entities.Blocks;
@@ -15,6 +14,7 @@ namespace MultigridProjector.Patches
     // ReSharper disable once InconsistentNaming
     public static class MyProjectorClipboard_UpdateGridTransformations
     {
+        // Client only!
         // ReSharper disable once UnusedMember.Local
         private static bool Prefix(
             // ReSharper disable once InconsistentNaming
@@ -22,26 +22,12 @@ namespace MultigridProjector.Patches
             // ReSharper disable once InconsistentNaming
             MyProjectorBase ___m_projector)
         {
-            var clipboard = __instance;
             var projector = ___m_projector;
 
             try
             {
-                if (projector == null || projector.Closed || !projector.Enabled || !projector.IsFunctional || 
-                    !projector.AllowWelding || projector.AllowScaling || !clipboard.IsActive)
-                    return true;
-
                 if (!MultigridProjection.TryFindProjectionByProjector(projector, out var projection))
-                {
-                    // The projector must have a blueprint loaded
-                    var gridBuilders = projector.GetOriginalGridBuilders();
-                    if (gridBuilders == null || gridBuilders.Count == 0 || clipboard.CopiedGrids?.Count != gridBuilders.Count)
-                        return true;
-                    
-                    projection = MultigridProjection.Create(projector, gridBuilders);
-                    if (projection == null)
-                        return true;
-                }
+                    return true;
                 
                 // Align the preview grids to match any grids has already been built
                 projection.UpdateGridTransformations();

--- a/MultigridProjector/Patches/MyProjectorClipboard_UpdateGridTransformations.cs
+++ b/MultigridProjector/Patches/MyProjectorClipboard_UpdateGridTransformations.cs
@@ -28,9 +28,8 @@ namespace MultigridProjector.Patches
             {
                 if (!MultigridProjection.TryFindProjectionByProjector(projector, out var projection))
                     return true;
-                
-                // Align the preview grids to match any grids has already been built
-                projection.UpdateGridTransformations();
+
+                // Alignment is needed on server side as well, so it was moved into UpdateAfterSimulation
             }
             catch (Exception e)
             {

--- a/MultigridProjector/Patches/MyProjectorClipboard_UpdateGridTransformations.cs
+++ b/MultigridProjector/Patches/MyProjectorClipboard_UpdateGridTransformations.cs
@@ -27,7 +27,8 @@ namespace MultigridProjector.Patches
 
             try
             {
-                if (projector == null || projector.Closed || !projector.Enabled || !projector.IsFunctional || !clipboard.IsActive)
+                if (projector == null || projector.Closed || !projector.Enabled || !projector.IsFunctional || 
+                    !projector.AllowWelding || projector.AllowScaling || !clipboard.IsActive)
                     return true;
 
                 if (!MultigridProjection.TryFindProjectionByProjector(projector, out var projection))

--- a/MultigridProjectorClient/Mod/metadata.mod
+++ b/MultigridProjectorClient/Mod/metadata.mod
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ModMetadata xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <ModVersion>0.2.2</ModVersion>
+  <ModVersion>0.2.3</ModVersion>
 </ModMetadata>

--- a/MultigridProjectorClient/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorClient/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.2.2.0")]
-[assembly: AssemblyFileVersion("0.2.2.0")]
+[assembly: AssemblyVersion("0.2.3.0")]
+[assembly: AssemblyFileVersion("0.2.3.0")]

--- a/MultigridProjectorModApiTest/Mod/metadata.mod
+++ b/MultigridProjectorModApiTest/Mod/metadata.mod
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ModMetadata xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <ModVersion>0.2.2</ModVersion>
+  <ModVersion>0.2.3</ModVersion>
 </ModMetadata>

--- a/MultigridProjectorModApiTest/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorModApiTest/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.2.2.0")]
-[assembly: AssemblyFileVersion("0.2.2.0")]
+[assembly: AssemblyVersion("0.2.3.0")]
+[assembly: AssemblyFileVersion("0.2.3.0")]

--- a/MultigridProjectorServer/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorServer/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.2.2.0")]
-[assembly: AssemblyFileVersion("0.2.2.0")]
+[assembly: AssemblyVersion("0.2.3.0")]
+[assembly: AssemblyFileVersion("0.2.3.0")]

--- a/MultigridProjectorServer/manifest.xml
+++ b/MultigridProjectorServer/manifest.xml
@@ -3,5 +3,5 @@
   <Name>Multigrid Projector</Name>
   <Guid>d9359ba0-9a69-41c3-971d-eb5170adb97e</Guid>
   <Repository>MultigridProjectorServer</Repository>
-  <Version>v0.2.2</Version>
+  <Version>v0.2.3</Version>
 </PluginManifest>


### PR DESCRIPTION
- Fixed unweldable blocks, it was caused by inconsistent state on server side due to not running all required code there
- Moving/rotating the projection is handled properly
- Projection can be turned off as expected
- Not littering top parts everywhere if the projection is moved
- Not affecting the cut&paste clipboard at all
- Better scheduling of the update work allows for more continuous welding
- Shutting down the projection as expected if Keep Projection is unchecked after the build is complete
- Stricter verification of build requests coming from clients without MGP client plugin installed or from MGP incompatible mods
- This is to prevent building blocks to wrong places and of wrong size
- Developers only: The `FullyBuilt` block state now appears in the API. It was in the enum before, so no change of API