### PR TITLE
Bugfix/welding

### DIFF
--- a/MultigridProjector/Api/IMultigridProjectorApi.cs
+++ b/MultigridProjector/Api/IMultigridProjectorApi.cs
@@ -7,7 +7,7 @@ namespace MultigridProjector.Api
 {
     public interface IMultigridProjectorApi
     {
-        // Multigrid Projector version: 0.2.5
+        // Multigrid Projector version: 0.2.6
         string Version { get; }
 
         // Returns the number of subgrids in the active projection, returns zero if there is no projection

--- a/MultigridProjector/Logic/MultigridProjectorApiProvider.cs
+++ b/MultigridProjector/Logic/MultigridProjectorApiProvider.cs
@@ -16,7 +16,7 @@ namespace MultigridProjector.Logic
         private static MultigridProjectorApiProvider _api;
         public static IMultigridProjectorApi Api => _api ?? (_api = new MultigridProjectorApiProvider());
 
-        public string Version => "0.2.5";
+        public string Version => "0.2.6";
 
         public int GetSubgridCount(long projectorId)
         {

--- a/MultigridProjector/Logic/Subgrid.cs
+++ b/MultigridProjector/Logic/Subgrid.cs
@@ -345,12 +345,14 @@ namespace MultigridProjector.Logic
         {
             if (!HasBuilt) return;
 
+            // Must refresh the preview, even if the block added does not overlap any preview blocks.
+            // Failing to do so may cause the first block not to be weldable due to the lack of refresh.
+            // FIXME: Optimize by limiting the update only to the volume around the block added
+            RequestUpdate();
+
             var previewSlimBlock = PreviewGrid.GetOverlappingBlock(slimBlock);
             if (previewSlimBlock == null)
                 return;
-
-            // FIXME: Optimize by limiting the update only to the volume around the block added
-            RequestUpdate();
 
             if (slimBlock.FatBlock is MyTerminalBlock terminalBlock)
             {
@@ -382,12 +384,14 @@ namespace MultigridProjector.Logic
         {
             if (!HasBuilt) return;
 
+            // Must refresh the preview, even if the block removed does not overlap any preview blocks.
+            // Failing to do so may cause blocks still showing up weldable due to the lack of refresh.
+            // FIXME: Optimize by limiting the update only to the volume around the block removed
+            RequestUpdate();
+
             var previewSlimBlock = PreviewGrid.GetOverlappingBlock(slimBlock);
             if (previewSlimBlock == null)
                 return;
-
-            // FIXME: Optimize by limiting the update only to the volume around the block removed
-            RequestUpdate();
 
             if (slimBlock.FatBlock is MyTerminalBlock terminalBlock)
             {

--- a/MultigridProjector/Logic/Subgrid.cs
+++ b/MultigridProjector/Logic/Subgrid.cs
@@ -44,7 +44,7 @@ namespace MultigridProjector.Logic
         // Mechanical top blocks on this subgrid by cube position
         public readonly Dictionary<Vector3I, TopConnection> TopConnections = new Dictionary<Vector3I, TopConnection>();
 
-        // Requests rescanning the preview blocks
+        // Requests rescanning the preview blocks, the initial true value starts the first scan
         public bool IsUpdateRequested = true;
 
         // Projected and built block states, built block changes are detected by the background worker, visuals are updated by the main thread

--- a/MultigridProjector/Logic/VisualState.cs
+++ b/MultigridProjector/Logic/VisualState.cs
@@ -1,0 +1,10 @@
+namespace MultigridProjector.Logic
+{
+    public enum VisualState
+    {
+        None = 0,
+        Hidden = 1,
+        Hologram = 2,
+        Transparent = 3,
+    }
+}

--- a/MultigridProjector/MultigridProjector.projitems
+++ b/MultigridProjector/MultigridProjector.projitems
@@ -18,6 +18,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Logic\ProjectedBlock.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Logic\BlockMinLocation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Logic\MultigridProjectorApiProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Logic\VisualState.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Patches\MyCubeGrid_TestPlacementAreaCube.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Patches\MyGridPhysicalHierarchy_BreakLink.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Patches\MyMechanicalConnectionBlockBase_CreateTopPart.cs" />

--- a/MultigridProjectorClient/Mod/metadata.mod
+++ b/MultigridProjectorClient/Mod/metadata.mod
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ModMetadata xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <ModVersion>0.2.5</ModVersion>
+  <ModVersion>0.2.6</ModVersion>
 </ModMetadata>

--- a/MultigridProjectorClient/Patches/MyProjectorBase_UpdateProjection.cs
+++ b/MultigridProjectorClient/Patches/MyProjectorBase_UpdateProjection.cs
@@ -15,8 +15,14 @@ namespace MultigridProjector.Patches
         // ReSharper disable once UnusedMember.Local
         private static bool Prefix(MyProjectorBase __instance)
         {
+            var projector = __instance;
+
+            // Console blocks set up the hologram look here
+            if (!projector.AllowWelding || projector.AllowScaling)
+                return true;
+
             // Disallow any use of the original ProjectorUpdateWork
-            // In theory this is not called at all, just in case.
+            // In theory this is not called for projectors, but disable it just in case.
             return false;
         }
     }

--- a/MultigridProjectorClient/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorClient/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.2.5.0")]
-[assembly: AssemblyFileVersion("0.2.5.0")]
+[assembly: AssemblyVersion("0.2.6.0")]
+[assembly: AssemblyFileVersion("0.2.6.0")]

--- a/MultigridProjectorModApiTest/Mod/metadata.mod
+++ b/MultigridProjectorModApiTest/Mod/metadata.mod
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ModMetadata xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <ModVersion>0.2.5</ModVersion>
+  <ModVersion>0.2.6</ModVersion>
 </ModMetadata>

--- a/MultigridProjectorModApiTest/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorModApiTest/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.2.5.0")]
-[assembly: AssemblyFileVersion("0.2.5.0")]
+[assembly: AssemblyVersion("0.2.6.0")]
+[assembly: AssemblyFileVersion("0.2.6.0")]

--- a/MultigridProjectorServer/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorServer/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.2.5.0")]
-[assembly: AssemblyFileVersion("0.2.5.0")]
+[assembly: AssemblyVersion("0.2.6.0")]
+[assembly: AssemblyFileVersion("0.2.6.0")]

--- a/MultigridProjectorServer/manifest.xml
+++ b/MultigridProjectorServer/manifest.xml
@@ -3,5 +3,5 @@
   <Name>Multigrid Projector</Name>
   <Guid>d9359ba0-9a69-41c3-971d-eb5170adb97e</Guid>
   <Repository>MultigridProjectorServer</Repository>
-  <Version>v0.2.5</Version>
+  <Version>v0.2.6</Version>
 </PluginManifest>


### PR DESCRIPTION
0.2.6

- Fixed refreshing preview updates on adding/removing blocks not part of the projection (first block now becomes weldable as expected when you put a block next to it)
- Fixed console block visuals (they were not transparent)
- Client performance: Not calling SetTransparency if not needed (reflection is slow)