### PR TITLE
Bugfix/0.3.2

### DIFF
--- a/MultigridProjector/Api/IMultigridProjectorApi.cs
+++ b/MultigridProjector/Api/IMultigridProjectorApi.cs
@@ -7,7 +7,7 @@ namespace MultigridProjector.Api
 {
     public interface IMultigridProjectorApi
     {
-        // Multigrid Projector version: 0.3.1
+        // Multigrid Projector version: 0.3.2
         string Version { get; }
 
         // Returns the number of subgrids in the active projection, returns zero if there is no projection

--- a/MultigridProjector/Logic/MultigridProjection.cs
+++ b/MultigridProjector/Logic/MultigridProjection.cs
@@ -147,6 +147,9 @@ namespace MultigridProjector.Logic
 
             Initialized = true;
 
+            foreach (var subgrid in SupportedSubgrids)
+                subgrid.RequestUpdate();
+
             ForceUpdateProjection();
         }
 

--- a/MultigridProjector/Logic/MultigridProjectorApiProvider.cs
+++ b/MultigridProjector/Logic/MultigridProjectorApiProvider.cs
@@ -16,7 +16,7 @@ namespace MultigridProjector.Logic
         private static MultigridProjectorApiProvider _api;
         public static IMultigridProjectorApi Api => _api ?? (_api = new MultigridProjectorApiProvider());
 
-        public string Version => "0.3.1";
+        public string Version => "0.3.2";
 
         public int GetSubgridCount(long projectorId)
         {

--- a/MultigridProjector/Logic/MultigridUpdateWork.cs
+++ b/MultigridProjector/Logic/MultigridUpdateWork.cs
@@ -16,7 +16,7 @@ namespace MultigridProjector.Logic
         // Concurrency: The update work must write only into the dedicated members of subgrids
         private MultigridProjection _projection;
         private MyProjectorBase Projector => _projection.Projector;
-        private List<Subgrid> Subgrids => _projection.Subgrids;
+        private IEnumerable<Subgrid> SupportedSubgrids => _projection.SupportedSubgrids;
 
         // Task control
         private Task _task;
@@ -84,7 +84,7 @@ namespace MultigridProjector.Logic
 
         private void UpdateBlockStatesAndCollectStatistics(WorkData workData = null)
         {
-            foreach (var subgrid in Subgrids)
+            foreach (var subgrid in SupportedSubgrids)
             {
                 if(ShouldStop) break;
                 subgrid.UpdateBlockStatesBackgroundWork(Projector);
@@ -93,7 +93,7 @@ namespace MultigridProjector.Logic
 
         private void FindBuiltMechanicalConnections()
         {
-            foreach (var subgrid in Subgrids)
+            foreach (var subgrid in SupportedSubgrids)
             {
                 if(ShouldStop) break;
                 subgrid.FindBuiltBaseConnectionsBackgroundWork();

--- a/MultigridProjector/Logic/ProjectionStats.cs
+++ b/MultigridProjector/Logic/ProjectionStats.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -37,23 +38,30 @@ namespace MultigridProjector.Logic
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void RegisterBlock(MySlimBlock slimBlock, BlockState blockState)
         {
-            if (blockState == BlockState.FullyBuilt)
+            var armor = slimBlock.FatBlock == null;
+
+            switch (blockState)
             {
-                if (slimBlock.FatBlock == null)
-                    BuiltArmorBlocks++;
-                return;
+                case BlockState.Buildable:
+                case BlockState.BeingBuilt:
+                    BuildableBlocks++;
+                    break;
+
+                case BlockState.FullyBuilt:
+                    if (armor)
+                        BuiltArmorBlocks++;
+                    return;
             }
 
             RemainingBlocks++;
 
-            var fatBlock = slimBlock.FatBlock;
-            if (fatBlock == null)
+            if (armor)
             {
                 RemainingArmorBlocks++;
                 return;
             }
 
-            var blockDefinition = fatBlock.BlockDefinition;
+            var blockDefinition = slimBlock.FatBlock.BlockDefinition;
             RemainingBlocksPerType[blockDefinition] = RemainingBlocksPerType.GetValueOrDefault(blockDefinition) + 1;
         }
 

--- a/MultigridProjector/Logic/Subgrid.cs
+++ b/MultigridProjector/Logic/Subgrid.cs
@@ -71,7 +71,7 @@ namespace MultigridProjector.Logic
             DisableFunctionalBlocks();
             CreateBlockModels();
 
-            CreateMechanicalConnections(projection);
+            FindMechanicalConnections(projection);
         }
 
         private void DisableFunctionalBlocks()
@@ -105,7 +105,7 @@ namespace MultigridProjector.Logic
             Blocks.Clear();
         }
 
-        private void CreateMechanicalConnections(MultigridProjection projection)
+        private void FindMechanicalConnections(MultigridProjection projection)
         {
             foreach (var slimBlock in PreviewGrid.CubeBlocks)
                 switch (slimBlock.FatBlock)

--- a/MultigridProjector/Logic/Subgrid.cs
+++ b/MultigridProjector/Logic/Subgrid.cs
@@ -44,8 +44,8 @@ namespace MultigridProjector.Logic
         // Mechanical top blocks on this subgrid by cube position
         public readonly Dictionary<Vector3I, TopConnection> TopConnections = new Dictionary<Vector3I, TopConnection>();
 
-        // Requests rescanning the preview blocks, the initial true value starts the first scan
-        public bool IsUpdateRequested = true;
+        // Requests rescanning the preview blocks
+        public bool IsUpdateRequested;
 
         // Indicates whether the preview grid is supported for welding, e.g. connected to the first preview grid
         public bool Supported;
@@ -185,7 +185,7 @@ namespace MultigridProjector.Logic
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void RequestUpdate()
         {
-            IsUpdateRequested = true;
+            IsUpdateRequested = Supported;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -566,7 +566,7 @@ namespace MultigridProjector.Logic
 
         public void UpdateBlockStatesBackgroundWork(MyProjectorBase projector)
         {
-            if (!IsUpdateRequested || !Supported)
+            if (!IsUpdateRequested)
                 return;
 
             IsUpdateRequested = false;

--- a/MultigridProjectorClient/Mod/metadata.mod
+++ b/MultigridProjectorClient/Mod/metadata.mod
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ModMetadata xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <ModVersion>0.3.1</ModVersion>
+  <ModVersion>0.3.2</ModVersion>
 </ModMetadata>

--- a/MultigridProjectorClient/MultigridProjectorPlugin.cs
+++ b/MultigridProjectorClient/MultigridProjectorPlugin.cs
@@ -11,7 +11,7 @@ namespace MultigridProjectorClient
     // ReSharper disable once UnusedType.Global
     public class MultigridProjectorPlugin : IPlugin
     {
-        private Harmony Harmony => new Harmony("com.spaceengineers.multigridprojector");
+        private static Harmony Harmony => new Harmony("com.spaceengineers.multigridprojector");
 
         public void Init(object gameInstance)
         {
@@ -20,7 +20,16 @@ namespace MultigridProjectorClient
             PluginLog.Info("Loading client plugin");
             try
             {
-                EnsureOriginal.VerifyAll();
+                try
+                {
+                    EnsureOriginal.VerifyAll();
+                }
+                catch (NotSupportedException e)
+                {
+                    PluginLog.Error(e, "Disabled the plugin due to potentially incompatible code changes in the game or plugin patch collisions. Please report the exception below on the SE Mods Discord (invite is on the Workshop page):");
+                    return;
+                }
+
                 Harmony.PatchAll();
 
                 MySession.OnLoading += OnLoadSession;
@@ -39,6 +48,7 @@ namespace MultigridProjectorClient
             MySession.OnLoading -= OnLoadSession;
             // MySession.OnUnloading -= OnUnloading;
 
+            // NOTE: Unpatching caused problems for other plugins, so just keeping the plugin installed all the time, which is common practice with Plugin Loader
             // PluginLog.Info("Unloading the Multigrid Projector Client Plugin");
             // _harmony.UnpatchAll();
 

--- a/MultigridProjectorClient/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorClient/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.3.1.0")]
-[assembly: AssemblyFileVersion("0.3.1.0")]
+[assembly: AssemblyVersion("0.3.2.0")]
+[assembly: AssemblyFileVersion("0.3.2.0")]

--- a/MultigridProjectorClient/README.md
+++ b/MultigridProjectorClient/README.md
@@ -18,8 +18,8 @@ After enabling the plugin it will be active for all single player worlds you loa
 
 ## Server plugins
 
-- [Torch Server](https://torchapi.net/plugins/item/d9359ba0-9a69-41c3-971d-eb5170adb97e)
-- [Dedicated Server](https://www.ferenczi.eu/se/multigrid-projector/)
+- [Torch Server](https://torchapi.net/plugins/item/d9359ba0-9a69-41c3-971d-eb5170adb97e) (updated automatically by Torch)
+- [Dedicated Server](https://www.ferenczi.eu/se/multigrid-projector/) (requires manual updating)
 
 **If you play on a multiplayer (Dedicated or Torch) server, then both the server plugin (on server side) and the client plugin (on the player's machine) must be installed! Using only the client plugin will not work properly.**
 
@@ -56,7 +56,6 @@ Thank you and enjoy!
 - jiringgot
 - Kam Solastor
 - NeonDrip
-- NeVaR
 - opesoorry
 - NeVaR
 - Jimbo
@@ -73,6 +72,8 @@ Thank you and enjoy!
 - Spitfyre.pjs
 - Random000
 - gamemasterellison
+- Babyboarder
+- LordJ
 
 ### Creators
 - avaness - Plugin Loader, Racing Display
@@ -80,6 +81,7 @@ Thank you and enjoy!
 - Mike Dude - Guardians SE
 - Fred XVI - Racing maps
 - Kamikaze - M&M mod
+- Keleios
 - LTP
 
 **Thank you very much for all your support and hard work on testing!**

--- a/MultigridProjectorClient/README.md
+++ b/MultigridProjectorClient/README.md
@@ -57,6 +57,8 @@ Thank you and enjoy!
 - Kam Solastor
 - NeonDrip
 - opesoorry
+- jiringgot
+- N CG
 - NeVaR
 - Jimbo
 

--- a/MultigridProjectorClient/steam_description.txt
+++ b/MultigridProjectorClient/steam_description.txt
@@ -61,6 +61,8 @@ Thank you and enjoy!
 - Kam Solastor
 - NeonDrip
 - opesoorry
+- jiringgot
+- N CG
 - NeVaR
 - Jimbo
 

--- a/MultigridProjectorClient/steam_description.txt
+++ b/MultigridProjectorClient/steam_description.txt
@@ -21,8 +21,8 @@ After enabling the plugin it will be active for all single player worlds you loa
 
 [h2]Server plugins[/h2]
 [list]
-[*] [url=https://torchapi.net/plugins/item/d9359ba0-9a69-41c3-971d-eb5170adb97e]Torch Server[/url]
-[*] [url=https://www.ferenczi.eu/se/multigrid-projector/]Dedicated Server[/url]
+[*] [url=https://torchapi.net/plugins/item/d9359ba0-9a69-41c3-971d-eb5170adb97e]Torch Server[/url] (updated automatically by Torch)
+[*] [url=https://www.ferenczi.eu/se/multigrid-projector/]Dedicated Server[/url] (requires manual updating)
 [/list]
 
 [b]If you play on a multiplayer (Dedicated or Torch) server, then both the server plugin (on server side) and the client plugin (on the player's machine) must be installed! Using only the client plugin will not work properly.[/b]
@@ -60,7 +60,6 @@ Thank you and enjoy!
 - jiringgot
 - Kam Solastor
 - NeonDrip
-- NeVaR
 - opesoorry
 - NeVaR
 - Jimbo
@@ -77,6 +76,8 @@ Thank you and enjoy!
 - Spitfyre.pjs
 - Random000
 - gamemasterellison
+- Babyboarder
+- LordJ
 
 [h3]Creators[/h3]
 - avaness - Plugin Loader, Racing Display
@@ -84,6 +85,7 @@ Thank you and enjoy!
 - Mike Dude - Guardians SE
 - Fred XVI - Racing maps
 - Kamikaze - M&M mod
+- Keleios
 - LTP
 
 [b]Thank you very much for all your support and hard work on testing![/b]

--- a/MultigridProjectorDedicated/MultigridProjectorPlugin.cs
+++ b/MultigridProjectorDedicated/MultigridProjectorPlugin.cs
@@ -17,7 +17,16 @@ namespace MultigridProjectorDedicated
             PluginLog.Info("Loading");
             try
             {
-                EnsureOriginal.VerifyAll();
+                try
+                {
+                    EnsureOriginal.VerifyAll();
+                }
+                catch (NotSupportedException e)
+                {
+                    PluginLog.Error("Found incompatible code changes in the game or plugin patch collisions. Please report the exception below on the SE Mods Discord (invite is on the Workshop page):");
+                    throw;
+                }
+
                 Harmony.PatchAll();
             }
             catch (Exception e)

--- a/MultigridProjectorDedicated/MultigridProjectorPlugin.cs
+++ b/MultigridProjectorDedicated/MultigridProjectorPlugin.cs
@@ -23,8 +23,8 @@ namespace MultigridProjectorDedicated
                 }
                 catch (NotSupportedException e)
                 {
-                    PluginLog.Error("Found incompatible code changes in the game or plugin patch collisions. Please report the exception below on the SE Mods Discord (invite is on the Workshop page):");
-                    throw;
+                    PluginLog.Error(e, "Disabled the plugin due to potentially incompatible code changes in the game or plugin patch collisions. Please report the exception below on the SE Mods Discord (invite is on the Workshop page):");
+                    return;
                 }
 
                 Harmony.PatchAll();

--- a/MultigridProjectorDedicated/Patches/MyProjectorBase_CanBuild.cs
+++ b/MultigridProjectorDedicated/Patches/MyProjectorBase_CanBuild.cs
@@ -10,7 +10,7 @@ namespace MultigridProjector.Patches
 {
     // ReSharper disable once UnusedType.Global
     [HarmonyPatch(typeof(MyProjectorBase))]
-    [HarmonyPatch("CanBuild", new []{typeof(MySlimBlock), typeof(bool)})]
+    [HarmonyPatch("CanBuild", typeof(MySlimBlock), typeof(bool))]
     [EnsureOriginal("a0424db9")]
     // ReSharper disable once InconsistentNaming
     public static class MyProjectorBase_CanBuild

--- a/MultigridProjectorDedicated/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorDedicated/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.3.1.0")]
-[assembly: AssemblyFileVersion("0.3.1.0")]
+[assembly: AssemblyVersion("0.3.2.0")]
+[assembly: AssemblyFileVersion("0.3.2.0")]

--- a/MultigridProjectorDedicated/README.md
+++ b/MultigridProjectorDedicated/README.md
@@ -41,7 +41,6 @@ Please vote on [Keen's bug ticket](https://support.keenswh.com/spaceengineers/pc
 - jiringgot
 - Kam Solastor
 - NeonDrip
-- NeVaR
 - opesoorry
 - NeVaR
 - Jimbo
@@ -59,6 +58,8 @@ Please vote on [Keen's bug ticket](https://support.keenswh.com/spaceengineers/pc
 - Spitfyre.pjs
 - Random000
 - gamemasterellison
+- Babyboarder
+- LordJ
 
 #### Creators
 
@@ -67,6 +68,7 @@ Please vote on [Keen's bug ticket](https://support.keenswh.com/spaceengineers/pc
 - Mike Dude - Guardians SE
 - Fred XVI - Racing maps
 - Kamikaze - M&M mod
+- Keleios
 - LTP
 
 Thank you very much for all your support and hard work on testing the plugin!

--- a/MultigridProjectorDedicated/README.md
+++ b/MultigridProjectorDedicated/README.md
@@ -42,6 +42,8 @@ Please vote on [Keen's bug ticket](https://support.keenswh.com/spaceengineers/pc
 - Kam Solastor
 - NeonDrip
 - opesoorry
+- jiringgot
+- N CG
 - NeVaR
 - Jimbo
 

--- a/MultigridProjectorDedicated/manifest.xml
+++ b/MultigridProjectorDedicated/manifest.xml
@@ -3,5 +3,5 @@
   <Name>Multigrid Projector</Name>
   <Guid>d4f47dcb-9c07-4c1a-bc8c-ce42e87683ee</Guid>
   <Repository>MultigridProjectorDedicated</Repository>
-  <Version>v0.3.1</Version>
+  <Version>v0.3.2</Version>
 </PluginManifest>

--- a/MultigridProjectorModApiTest/Mod/metadata.mod
+++ b/MultigridProjectorModApiTest/Mod/metadata.mod
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ModMetadata xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <ModVersion>0.3.1</ModVersion>
+  <ModVersion>0.3.2</ModVersion>
 </ModMetadata>

--- a/MultigridProjectorModApiTest/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorModApiTest/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.3.1.0")]
-[assembly: AssemblyFileVersion("0.3.1.0")]
+[assembly: AssemblyVersion("0.3.2.0")]
+[assembly: AssemblyFileVersion("0.3.2.0")]

--- a/MultigridProjectorServer/MultigridProjectorPlugin.cs
+++ b/MultigridProjectorServer/MultigridProjectorPlugin.cs
@@ -43,8 +43,8 @@ namespace MultigridProjectorServer
             }
             catch (NotSupportedException e)
             {
-                PluginLog.Error("Found incompatible code changes in the game or plugin patch collisions. Please report the exception below on the SE Mods Discord (invite is on the Workshop page):");
-                throw;
+                PluginLog.Error(e, "Disabled the plugin due to potentially incompatible code changes in the game or plugin patch collisions. Please report the exception below on the SE Mods Discord (invite is on the Workshop page):");
+                return;
             }
 
             Harmony.PatchAll();

--- a/MultigridProjectorServer/MultigridProjectorServer.csproj
+++ b/MultigridProjectorServer/MultigridProjectorServer.csproj
@@ -94,6 +94,7 @@
     </ItemGroup>
     <ItemGroup>
         <Compile Include="Api\MultigridProjectorTorchAgent.cs" />
+        <Compile Include="EnsureOriginalTorch.cs" />
         <Compile Include="MultigridProjectorCommands.cs" />
         <Compile Include="MultigridProjectorConfig.cs" />
         <Compile Include="MultigridProjectorPlugin.cs" />

--- a/MultigridProjectorServer/Patches/MyMechanicalConnectionBlockBase_CreateTopPartAndAttach.cs
+++ b/MultigridProjectorServer/Patches/MyMechanicalConnectionBlockBase_CreateTopPartAndAttach.cs
@@ -5,9 +5,10 @@ using MultigridProjector.Utilities;
 using Sandbox.Game.Entities.Blocks;
 using Torch.Managers.PatchManager;
 
-namespace MultigridProjector.Patches
+namespace MultigridProjectorServer.Patches
 {
     [PatchShim]
+    [EnsureOriginalTorch(typeof(MyMechanicalConnectionBlockBase), "CreateTopPartAndAttach", null,"e1d2892d")]
     // ReSharper disable once InconsistentNaming
     // ReSharper disable once UnusedType.Global
     public static class MyMechanicalConnectionBlockBase_CreateTopPartAndAttach

--- a/MultigridProjectorServer/Patches/MyMechanicalConnectionBlockBase_RaiseAttachedEntityChanged.cs
+++ b/MultigridProjectorServer/Patches/MyMechanicalConnectionBlockBase_RaiseAttachedEntityChanged.cs
@@ -5,9 +5,10 @@ using MultigridProjector.Utilities;
 using Sandbox.Game.Entities.Blocks;
 using Torch.Managers.PatchManager;
 
-namespace MultigridProjector.Patches
+namespace MultigridProjectorServer.Patches
 {
     [PatchShim]
+    [EnsureOriginalTorch(typeof(MyMechanicalConnectionBlockBase), "RaiseAttachedEntityChanged", null,"f0a1b3d3")]
     // ReSharper disable once InconsistentNaming
     // ReSharper disable once UnusedType.Global
     public static class MyMechanicalConnectionBlockBase_RaiseAttachedEntityChanged

--- a/MultigridProjectorServer/Patches/MyProjectorBase_Build.cs
+++ b/MultigridProjectorServer/Patches/MyProjectorBase_Build.cs
@@ -6,9 +6,10 @@ using Sandbox.Game.Entities.Blocks;
 using Sandbox.Game.Entities.Cube;
 using Torch.Managers.PatchManager;
 
-namespace MultigridProjector.Patches
+namespace MultigridProjectorServer.Patches
 {
     [PatchShim]
+    [EnsureOriginalTorch(typeof(MyProjectorBase), "Build", null, "56be06c3")]
     // ReSharper disable once InconsistentNaming
     // ReSharper disable once UnusedType.Global
     public static class MyProjectorBase_Build

--- a/MultigridProjectorServer/Patches/MyProjectorBase_BuildInternal.cs
+++ b/MultigridProjectorServer/Patches/MyProjectorBase_BuildInternal.cs
@@ -6,9 +6,10 @@ using Sandbox.Game.Entities.Blocks;
 using Torch.Managers.PatchManager;
 using VRageMath;
 
-namespace MultigridProjectorServer
+namespace MultigridProjectorServer.Patches
 {
     [PatchShim]
+    [EnsureOriginalTorch(typeof(MyProjectorBase), "BuildInternal", null,"b5ce7ac2")]
     // ReSharper disable once InconsistentNaming
     // ReSharper disable once UnusedType.Global
     public static class MyProjectorBase_BuildInternal

--- a/MultigridProjectorServer/Patches/MyProjectorBase_CanBuild.cs
+++ b/MultigridProjectorServer/Patches/MyProjectorBase_CanBuild.cs
@@ -7,15 +7,17 @@ using Sandbox.Game.Entities.Cube;
 using Sandbox.ModAPI;
 using Torch.Managers.PatchManager;
 
-namespace MultigridProjector.Patches
+namespace MultigridProjectorServer.Patches
 {
     [PatchShim]
+    [EnsureOriginalTorch(typeof(MyProjectorBase), "CanBuild", new []{typeof(MySlimBlock), typeof(bool)}, "a0424db9")]
     // ReSharper disable once InconsistentNaming
     // ReSharper disable once UnusedType.Global
     public static class MyProjectorBase_CanBuild
     {
-        public static void Patch(PatchContext ctx) => ctx.GetPattern(typeof (MyProjectorBase).GetMethod("CanBuild", BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public)).Prefixes.Add(typeof (MyProjectorBase_CanBuild).GetMethod(nameof(Prefix), BindingFlags.Static | BindingFlags.NonPublic));
-        
+        public static void Patch(PatchContext ctx) => ctx.GetPattern(typeof(MyProjectorBase).GetMethod("CanBuild", BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public)).Prefixes
+            .Add(typeof(MyProjectorBase_CanBuild).GetMethod(nameof(Prefix), BindingFlags.Static | BindingFlags.NonPublic));
+
         [ServerOnly]
         // ReSharper disable once UnusedMember.Local
         private static bool Prefix(

--- a/MultigridProjectorServer/Patches/MyProjectorBase_GetObjectBuilderCubeBlock.cs
+++ b/MultigridProjectorServer/Patches/MyProjectorBase_GetObjectBuilderCubeBlock.cs
@@ -6,15 +6,17 @@ using Sandbox.Game.Entities.Blocks;
 using Torch.Managers.PatchManager;
 using VRage.Game;
 
-namespace MultigridProjector.Patches
+namespace MultigridProjectorServer.Patches
 {
     [PatchShim]
+    [EnsureOriginalTorch(typeof(MyProjectorBase), "GetObjectBuilderCubeBlock", null, "6b6ba5b3")]
     // ReSharper disable once InconsistentNaming
     // ReSharper disable once UnusedType.Global
     public static class MyProjectorBase_GetObjectBuilderCubeBlock
     {
-        public static void Patch(PatchContext ctx) => ctx.GetPattern(typeof (MyProjectorBase).GetMethod("GetObjectBuilderCubeBlock", BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public)).Suffixes.Add(typeof (MyProjectorBase_GetObjectBuilderCubeBlock).GetMethod(nameof(Suffix), BindingFlags.Static | BindingFlags.NonPublic));
-        
+        public static void Patch(PatchContext ctx) => ctx.GetPattern(typeof(MyProjectorBase).GetMethod("GetObjectBuilderCubeBlock", BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public)).Suffixes
+            .Add(typeof(MyProjectorBase_GetObjectBuilderCubeBlock).GetMethod(nameof(Suffix), BindingFlags.Static | BindingFlags.NonPublic));
+
         [ServerOnly]
         // ReSharper disable once UnusedMember.Local
         private static void Suffix(

--- a/MultigridProjectorServer/Patches/MyProjectorBase_Init.cs
+++ b/MultigridProjectorServer/Patches/MyProjectorBase_Init.cs
@@ -7,15 +7,16 @@ using Sandbox.Game.Entities.Blocks;
 using Torch.Managers.PatchManager;
 using VRage.Game;
 
-namespace MultigridProjector.Patches
+namespace MultigridProjectorServer.Patches
 {
     [PatchShim]
+    [EnsureOriginalTorch(typeof(MyProjectorBase), "Init", null, "71397e45")]
     // ReSharper disable once InconsistentNaming
     // ReSharper disable once UnusedType.Global
     public static class MyProjectorBase_Init
     {
-        public static void Patch(PatchContext ctx) => ctx.GetPattern(typeof (MyProjectorBase).GetMethod("Init", BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public)).Suffixes.Add(typeof (MyProjectorBase_Init).GetMethod(nameof(Suffix), BindingFlags.Static | BindingFlags.NonPublic));
-        
+        public static void Patch(PatchContext ctx) => ctx.GetPattern(typeof(MyProjectorBase).GetMethod("Init", BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public)).Suffixes.Add(typeof(MyProjectorBase_Init).GetMethod(nameof(Suffix), BindingFlags.Static | BindingFlags.NonPublic));
+
         [ServerOnly]
         // ReSharper disable once UnusedMember.Local
         private static void Suffix(

--- a/MultigridProjectorServer/Patches/MyProjectorBase_InitializeClipboard.cs
+++ b/MultigridProjectorServer/Patches/MyProjectorBase_InitializeClipboard.cs
@@ -5,9 +5,10 @@ using MultigridProjector.Utilities;
 using Sandbox.Game.Entities.Blocks;
 using Torch.Managers.PatchManager;
 
-namespace MultigridProjectorServer
+namespace MultigridProjectorServer.Patches
 {
     [PatchShim]
+    [EnsureOriginalTorch(typeof(MyProjectorBase), "InitializeClipboard", null, "b7140f1d")]
     // ReSharper disable once InconsistentNaming
     // ReSharper disable once UnusedType.Global
     public static class MyProjectorBase_InitializeClipboard

--- a/MultigridProjectorServer/Patches/MyProjectorBase_OnBlockAdded.cs
+++ b/MultigridProjectorServer/Patches/MyProjectorBase_OnBlockAdded.cs
@@ -5,9 +5,10 @@ using MultigridProjector.Utilities;
 using Sandbox.Game.Entities.Blocks;
 using Torch.Managers.PatchManager;
 
-namespace MultigridProjector.Patches
+namespace MultigridProjectorServer.Patches
 {
     [PatchShim]
+    [EnsureOriginalTorch(typeof(MyProjectorBase), "previewGrid_OnBlockAdded", null, "95f13809")]
     // ReSharper disable once InconsistentNaming
     // ReSharper disable once UnusedType.Global
     public static class MyProjectorBase_OnBlockAdded

--- a/MultigridProjectorServer/Patches/MyProjectorBase_OnBlockRemoved.cs
+++ b/MultigridProjectorServer/Patches/MyProjectorBase_OnBlockRemoved.cs
@@ -5,9 +5,10 @@ using MultigridProjector.Utilities;
 using Sandbox.Game.Entities.Blocks;
 using Torch.Managers.PatchManager;
 
-namespace MultigridProjector.Patches
+namespace MultigridProjectorServer.Patches
 {
     [PatchShim]
+    [EnsureOriginalTorch(typeof(MyProjectorBase), "previewGrid_OnBlockRemoved", null, "a3aa98dd")]
     // ReSharper disable once InconsistentNaming
     // ReSharper disable once UnusedType.Global
     public static class MyProjectorBase_OnBlockRemoved

--- a/MultigridProjectorServer/Patches/MyProjectorBase_Remap.cs
+++ b/MultigridProjectorServer/Patches/MyProjectorBase_Remap.cs
@@ -2,14 +2,14 @@ using System;
 using System.Reflection;
 using HarmonyLib;
 using MultigridProjector.Extensions;
-using Sandbox.Game.Multiplayer;
 using MultigridProjector.Utilities;
 using Sandbox.Game.Entities.Blocks;
 using Torch.Managers.PatchManager;
 
-namespace MultigridProjector.Patches
+namespace MultigridProjectorServer.Patches
 {
     [PatchShim]
+    [EnsureOriginalTorch(typeof(MyProjectorBase), "Remap", null, "bce65541")]
     // ReSharper disable once InconsistentNaming
     // ReSharper disable once UnusedType.Global
     public static class MyProjectorBase_Remap

--- a/MultigridProjectorServer/Patches/MyProjectorBase_RemoveProjection.cs
+++ b/MultigridProjectorServer/Patches/MyProjectorBase_RemoveProjection.cs
@@ -5,9 +5,10 @@ using MultigridProjector.Utilities;
 using Sandbox.Game.Entities.Blocks;
 using Torch.Managers.PatchManager;
 
-namespace MultigridProjector.Patches
+namespace MultigridProjectorServer.Patches
 {
     [PatchShim]
+    [EnsureOriginalTorch(typeof(MyProjectorBase), "RemoveProjection", null, "f6fc8084")]
     // ReSharper disable once InconsistentNaming
     // ReSharper disable once UnusedType.Global
     public static class MyProjectorBase_RemoveProjection

--- a/MultigridProjectorServer/Patches/MyProjectorBase_UpdateAfterSimulation.cs
+++ b/MultigridProjectorServer/Patches/MyProjectorBase_UpdateAfterSimulation.cs
@@ -4,11 +4,11 @@ using MultigridProjector.Logic;
 using MultigridProjector.Utilities;
 using Sandbox.Game.Entities.Blocks;
 using Torch.Managers.PatchManager;
-using VRage.Game.Entity.EntityComponents.Interfaces;
 
-namespace MultigridProjector.Patches
+namespace MultigridProjectorServer.Patches
 {
     [PatchShim]
+    [EnsureOriginalTorch(typeof(MyProjectorBase), "UpdateAfterSimulation", null, "47184779")]
     // ReSharper disable once InconsistentNaming
     // ReSharper disable once UnusedType.Global
     public static class MyProjectorBase_UpdateAfterSimulation

--- a/MultigridProjectorServer/Patches/MyProjectorBase_UpdateStats.cs
+++ b/MultigridProjectorServer/Patches/MyProjectorBase_UpdateStats.cs
@@ -5,9 +5,10 @@ using MultigridProjector.Utilities;
 using Sandbox.Game.Entities.Blocks;
 using Torch.Managers.PatchManager;
 
-namespace MultigridProjector.Patches
+namespace MultigridProjectorServer.Patches
 {
     [PatchShim]
+    [EnsureOriginalTorch(typeof(MyProjectorBase), "UpdateStats", null, "ee9fdb75")]
     // ReSharper disable once InconsistentNaming
     // ReSharper disable once UnusedType.Global
     public static class MyProjectorBase_UpdateStats

--- a/MultigridProjectorServer/Patches/MyProjectorClipboard_UpdateGridTransformations.cs
+++ b/MultigridProjectorServer/Patches/MyProjectorClipboard_UpdateGridTransformations.cs
@@ -7,9 +7,10 @@ using Sandbox.Game.Entities.Blocks;
 using Sandbox.Game.Entities.Cube;
 using Torch.Managers.PatchManager;
 
-namespace MultigridProjector.Patches
+namespace MultigridProjectorServer.Patches
 {
     [PatchShim]
+    [EnsureOriginalTorch(typeof(MyProjectorClipboard), "UpdateGridTransformations", null, "6a6d82b9")]
     // ReSharper disable once InconsistentNaming
     // ReSharper disable once UnusedType.Global
     public static class MyProjectorClipboard_UpdateGridTransformations

--- a/MultigridProjectorServer/Patches/MyShipWelder_FindProjectedBlocks.cs
+++ b/MultigridProjectorServer/Patches/MyShipWelder_FindProjectedBlocks.cs
@@ -10,9 +10,10 @@ using SpaceEngineers.Game.Entities.Blocks;
 using Torch.Managers.PatchManager;
 using VRageMath;
 
-namespace MultigridProjector.Patches
+namespace MultigridProjectorServer.Patches
 {
     [PatchShim]
+    [EnsureOriginalTorch(typeof(MyShipWelder), "FindProjectedBlocks", null, "30c15aa0")]
     // ReSharper disable once InconsistentNaming
     // ReSharper disable once UnusedType.Global
     public static class MyShipWelder_FindProjectedBlocks

--- a/MultigridProjectorServer/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorServer/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.3.1.0")]
-[assembly: AssemblyFileVersion("0.3.1.0")]
+[assembly: AssemblyVersion("0.3.2.0")]
+[assembly: AssemblyFileVersion("0.3.2.0")]

--- a/MultigridProjectorServer/README.md
+++ b/MultigridProjectorServer/README.md
@@ -41,7 +41,6 @@ Please vote on [Keen's bug ticket](https://support.keenswh.com/spaceengineers/pc
 - jiringgot
 - Kam Solastor
 - NeonDrip
-- NeVaR
 - opesoorry
 - NeVaR
 - Jimbo
@@ -59,6 +58,8 @@ Please vote on [Keen's bug ticket](https://support.keenswh.com/spaceengineers/pc
 - Spitfyre.pjs
 - Random000
 - gamemasterellison
+- Babyboarder
+- LordJ
 
 #### Creators
 
@@ -67,6 +68,7 @@ Please vote on [Keen's bug ticket](https://support.keenswh.com/spaceengineers/pc
 - Mike Dude - Guardians SE
 - Fred XVI - Racing maps
 - Kamikaze - M&M mod
+- Keleios
 - LTP
 
 Thank you very much for all your support and hard work on testing the plugin!

--- a/MultigridProjectorServer/README.md
+++ b/MultigridProjectorServer/README.md
@@ -42,6 +42,8 @@ Please vote on [Keen's bug ticket](https://support.keenswh.com/spaceengineers/pc
 - Kam Solastor
 - NeonDrip
 - opesoorry
+- jiringgot
+- N CG
 - NeVaR
 - Jimbo
 

--- a/MultigridProjectorServer/manifest.xml
+++ b/MultigridProjectorServer/manifest.xml
@@ -3,5 +3,5 @@
   <Name>Multigrid Projector</Name>
   <Guid>d9359ba0-9a69-41c3-971d-eb5170adb97e</Guid>
   <Repository>MultigridProjectorServer</Repository>
-  <Version>v0.3.1</Version>
+  <Version>v0.3.2</Version>
 </PluginManifest>


### PR DESCRIPTION
0.3.2

- Reverse welding works (pistons needed a dangerous hack, keep me posted if the game crashes)
- Fixed the number of buildable blocks in the Detailed Info of projectors
- Fixed error on loading blueprints with modded mechanical connector blocks if the mod is missing
- Properly refreshing all subgrids on loading the projection
- Monitoring terminal blocks for grid connectivity changes (turning on merge block, for example)
- Properly ignoring unsupported subgrids (for example drones on connectors)
- Game code change and plugin patch collision detection for the Torch server plugin
- Documentation updates