### PR TITLE
Bugfix/0.3.4

### DIFF
--- a/MultigridProjector/Api/IMultigridProjectorApi.cs
+++ b/MultigridProjector/Api/IMultigridProjectorApi.cs
@@ -7,7 +7,7 @@ namespace MultigridProjector.Api
 {
     public interface IMultigridProjectorApi
     {
-        // Multigrid Projector version: 0.3.3
+        // Multigrid Projector version: 0.3.4
         string Version { get; }
 
         // Returns the number of subgrids in the active projection, returns zero if there is no projection

--- a/MultigridProjector/Logic/MultigridProjection.cs
+++ b/MultigridProjector/Logic/MultigridProjection.cs
@@ -1200,7 +1200,6 @@ System.NullReferenceException: Object reference not set to an instance of an obj
             }
 
             // Empty inventory, ammo (including already loaded ammo), also clears battery charge (which is wrong, see below)
-            blockBuilder.SetupForProjector();
             blockBuilder.ConstructionInventory = null;
 
             // Reset batteries to default charge
@@ -1221,7 +1220,7 @@ System.NullReferenceException: Object reference not set to an instance of an obj
             var visuals = new MyCubeGrid.MyBlockVisuals(previewBlock.ColorMaskHSV.PackHSVToUint(), skinId);
 
             // Actually build the block on both the server and all clients
-            builtGrid.BuildBlockRequestInternal(visuals, location, blockBuilder, builder, instantBuild, owner, MyEventContext.Current.IsLocallyInvoked ? steamId : MyEventContext.Current.Sender.Value);
+            builtGrid.BuildBlockRequestInternal(visuals, location, blockBuilder, builder, instantBuild, owner, MyEventContext.Current.IsLocallyInvoked ? steamId : MyEventContext.Current.Sender.Value, isProjection: true);
         }
 
         [Everywhere]
@@ -1284,7 +1283,7 @@ System.NullReferenceException: Object reference not set to an instance of an obj
                 return BuildCheckResult.OK;
 
             var gridPlacementSettings = new MyGridPlacementSettings {SnapMode = SnapMode.OneFreeAxis};
-            if (MyCubeGrid.TestPlacementAreaCube(builtGrid, ref gridPlacementSettings, min, max, previewBlock.Orientation, previewBlock.BlockDefinition, ignoredEntity: builtGrid))
+            if (MyCubeGrid.TestPlacementAreaCube(builtGrid, ref gridPlacementSettings, min, max, previewBlock.Orientation, previewBlock.BlockDefinition, ignoredEntity: builtGrid, isProjected: true))
                 return BuildCheckResult.OK;
 
             return BuildCheckResult.IntersectedWithSomethingElse;

--- a/MultigridProjector/Logic/MultigridProjection.cs
+++ b/MultigridProjector/Logic/MultigridProjection.cs
@@ -741,8 +741,6 @@ namespace MultigridProjector.Logic
             if (!Initialized || Projector.Closed || Subgrids.Count < 1)
                 return;
 
-            _stats.Clear();
-
             foreach (var subgrid in SupportedSubgrids)
             {
                 subgrid.UnregisterBuiltGrid();

--- a/MultigridProjector/Logic/MultigridProjectorApiProvider.cs
+++ b/MultigridProjector/Logic/MultigridProjectorApiProvider.cs
@@ -16,7 +16,7 @@ namespace MultigridProjector.Logic
         private static MultigridProjectorApiProvider _api;
         public static IMultigridProjectorApi Api => _api ?? (_api = new MultigridProjectorApiProvider());
 
-        public string Version => "0.3.3";
+        public string Version => "0.3.4";
 
         public int GetSubgridCount(long projectorId)
         {

--- a/MultigridProjector/Logic/ProjectionStats.cs
+++ b/MultigridProjector/Logic/ProjectionStats.cs
@@ -11,8 +11,8 @@ namespace MultigridProjector.Logic
     public class ProjectionStats
     {
         public int TotalBlocks;
+        public int TotalArmorBlocks;
         public int RemainingBlocks;
-        public int BuiltArmorBlocks;
         public int RemainingArmorBlocks;
         public int BuildableBlocks;
 
@@ -21,16 +21,19 @@ namespace MultigridProjector.Logic
         public bool Valid => TotalBlocks > 0;
         public bool IsBuildCompleted => Valid && RemainingBlocks == 0;
         public int BuiltBlocks => TotalBlocks - RemainingBlocks;
+        public int BuiltArmorBlocks => TotalArmorBlocks - RemainingArmorBlocks;
         public bool BuiltOnlyArmorBlocks => Valid && BuiltBlocks == BuiltArmorBlocks;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Clear(int totalBlocks=0)
+        public void Clear()
         {
-            TotalBlocks = totalBlocks;
-            RemainingBlocks = 0;
-            BuiltArmorBlocks = 0;
-            RemainingArmorBlocks = 0;
+            TotalBlocks = 0;
+            TotalArmorBlocks = 0;
+
             BuildableBlocks = 0;
+
+            RemainingBlocks = 0;
+            RemainingArmorBlocks = 0;
 
             RemainingBlocksPerType.Clear();
         }
@@ -38,7 +41,11 @@ namespace MultigridProjector.Logic
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void RegisterBlock(MySlimBlock slimBlock, BlockState blockState)
         {
+            TotalBlocks++;
+
             var armor = slimBlock.FatBlock == null;
+            if (armor)
+                TotalArmorBlocks++;
 
             switch (blockState)
             {
@@ -48,8 +55,6 @@ namespace MultigridProjector.Logic
                     break;
 
                 case BlockState.FullyBuilt:
-                    if (armor)
-                        BuiltArmorBlocks++;
                     return;
             }
 
@@ -69,15 +74,15 @@ namespace MultigridProjector.Logic
         public void Add(ProjectionStats other)
         {
             TotalBlocks += other.TotalBlocks;
-            RemainingBlocks += other.RemainingBlocks;
-            BuiltArmorBlocks += other.BuiltArmorBlocks;
-            RemainingArmorBlocks += other.RemainingArmorBlocks;
+            TotalArmorBlocks += other.TotalArmorBlocks;
+
             BuildableBlocks += other.BuildableBlocks;
 
+            RemainingBlocks += other.RemainingBlocks;
+            RemainingArmorBlocks += other.RemainingArmorBlocks;
+
             foreach (var (blockDefinition, count) in other.RemainingBlocksPerType)
-            {
                 RemainingBlocksPerType[blockDefinition] = RemainingBlocksPerType.GetValueOrDefault(blockDefinition) + count;
-            }
         }
     }
 }

--- a/MultigridProjector/Logic/Subgrid.cs
+++ b/MultigridProjector/Logic/Subgrid.cs
@@ -477,21 +477,7 @@ namespace MultigridProjector.Logic
         [Everywhere]
         private void OnGridSplit(MyCubeGrid grid1, MyCubeGrid grid2)
         {
-            MyCubeGrid builtGrid;
-            using (BuiltGridLock.Read())
-            {
-                builtGrid = BuiltGrid;
-            }
-
-            if (builtGrid == null)
-                return;
-
             UnregisterBuiltGrid();
-
-            if (builtGrid != grid1 && builtGrid != grid2)
-                return;
-
-            RegisterBuiltGrid(builtGrid);
         }
 
         [Everywhere]

--- a/MultigridProjector/Logic/Subgrid.cs
+++ b/MultigridProjector/Logic/Subgrid.cs
@@ -32,6 +32,9 @@ namespace MultigridProjector.Logic
         public bool HasBuilt => BuiltGrid != null;
         public MyCubeSize GridSizeEnum => PreviewGrid.GridSizeEnum;
 
+        // Initial statistics of the subgrid with none of the blocks welded
+        public readonly ProjectionStats InitialStats = new ProjectionStats();
+
         // Welding state statistics collected by the background worker
         public readonly ProjectionStats Stats = new ProjectionStats();
 
@@ -70,10 +73,11 @@ namespace MultigridProjector.Logic
 
             DisableFunctionalBlocks();
             CreateBlockModels();
-
+            CollectInitialStats();
             FindMechanicalConnections(projection);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void DisableFunctionalBlocks()
         {
             // Disable all functional blocks in the preview to avoid side effects, prevents ghost subgrids from projectors
@@ -81,6 +85,7 @@ namespace MultigridProjector.Logic
                 functionalBlock.Enabled = false;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void CreateBlockModels()
         {
             var blockBuilders = GridBuilder
@@ -93,6 +98,15 @@ namespace MultigridProjector.Logic
                 .ToDictionary(
                     previewBlock => previewBlock.Position,
                     previewBlock => new ProjectedBlock(previewBlock, blockBuilders[previewBlock.Min]));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void CollectInitialStats()
+        {
+            foreach (var slimBlock in PreviewGrid.CubeBlocks)
+                InitialStats.RegisterBlock(slimBlock, BlockState.NotBuildable);
+
+            Stats.Add(InitialStats);
         }
 
         public void Dispose()
@@ -274,7 +288,8 @@ namespace MultigridProjector.Logic
 
                 BuiltGrid = null;
 
-                Stats.Clear(PreviewGrid.CubeBlocks.Count);
+                Stats.Clear();
+                Stats.Add(InitialStats);
 
                 foreach (var projectedBlock in Blocks.Values)
                     projectedBlock.Clear();
@@ -596,7 +611,7 @@ namespace MultigridProjector.Logic
 
             IsUpdateRequested = false;
 
-            Stats.Clear(PreviewGrid.CubeBlocks.Count);
+            Stats.Clear();
 
             foreach (var projectedBlock in Blocks.Values)
             {

--- a/MultigridProjector/Patches/MyCubeGrid_TestPlacementAreaCube.cs
+++ b/MultigridProjector/Patches/MyCubeGrid_TestPlacementAreaCube.cs
@@ -23,7 +23,9 @@ namespace MultigridProjector.Patches
             typeof(MyCubeGrid),
             typeof(ulong),
             typeof(MyEntity),
-            typeof(bool)},
+            typeof(bool),
+            typeof(bool),
+        },
         new []
         {
             ArgumentType.Normal,
@@ -36,8 +38,9 @@ namespace MultigridProjector.Patches
             ArgumentType.Normal,
             ArgumentType.Normal,
             ArgumentType.Normal,
+            ArgumentType.Normal,
         })]
-    [EnsureOriginal("2b2afd1b")]
+    [EnsureOriginal("e8b488ba")]
     // ReSharper disable once InconsistentNaming
     public class MyCubeGrid_TestPlacementAreaCube
     {
@@ -46,10 +49,14 @@ namespace MultigridProjector.Patches
         private static void Postfix(
             MyCubeGrid targetGrid,
             Vector3I min,
+            bool isProjected,
             // ReSharper disable once InconsistentNaming
             ref bool __result)
         {
             if (__result)
+                return;
+
+            if (!isProjected)
                 return;
 
             try

--- a/MultigridProjectorClient/Mod/Data/Scripts/MultigridProjectorClient/EmptyMod.cs
+++ b/MultigridProjectorClient/Mod/Data/Scripts/MultigridProjectorClient/EmptyMod.cs
@@ -6,6 +6,7 @@ using VRage.Utils;
 // ReSharper disable once CheckNamespace
 namespace MultigridProjectorClient
 {
+#if STABLE
     [MySessionComponentDescriptor(MyUpdateOrder.NoUpdate)]
     // ReSharper disable once UnusedType.Global
     public class EmptyMod : MySessionComponentBase
@@ -19,4 +20,5 @@ namespace MultigridProjectorClient
             MyLog.Default.WriteLineAndConsole($"Multigrid Projector: {message}");
         }
     }
+#endif
 }

--- a/MultigridProjectorClient/Mod/metadata.mod
+++ b/MultigridProjectorClient/Mod/metadata.mod
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ModMetadata xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <ModVersion>0.3.3</ModVersion>
+  <ModVersion>0.3.4</ModVersion>
 </ModMetadata>

--- a/MultigridProjectorClient/MultigridProjectorClient.csproj
+++ b/MultigridProjectorClient/MultigridProjectorClient.csproj
@@ -87,7 +87,7 @@
         </Reference>
     </ItemGroup>
     <ItemGroup>
-        <Content Include="Mod\Data\Scripts\MultigridProjectorClient\EmptyMod.cs" />
+        <Compile Include="Mod\Data\Scripts\MultigridProjectorClient\EmptyMod.cs" />
         <Compile Include="MultigridProjectorPlugin.cs" />
         <Compile Include="MultigridProjectorSession.cs" />
         <Compile Include="Patches\MyMechanicalConnectionBlockBase_CreateTopPartAndAttach.cs" />

--- a/MultigridProjectorClient/Patches/MyProjectorBase_BuildInternal.cs
+++ b/MultigridProjectorClient/Patches/MyProjectorBase_BuildInternal.cs
@@ -12,7 +12,7 @@ namespace MultigridProjectorClient.Patches
     // ReSharper disable once UnusedType.Global
     [HarmonyPatch(typeof(MyProjectorBase))]
     [HarmonyPatch("BuildInternal")]
-    [EnsureOriginal("b5ce7ac2")]
+    [EnsureOriginal("55ff55cf")]
     // ReSharper disable once InconsistentNaming
     public static class MyProjectorBase_BuildInternal
     {

--- a/MultigridProjectorClient/Patches/MyProjectorBase_CanBuild.cs
+++ b/MultigridProjectorClient/Patches/MyProjectorBase_CanBuild.cs
@@ -11,7 +11,7 @@ namespace MultigridProjector.Patches
     // ReSharper disable once UnusedType.Global
     [HarmonyPatch(typeof(MyProjectorBase))]
     [HarmonyPatch("CanBuild", new []{typeof(MySlimBlock), typeof(bool)})]
-    [EnsureOriginal("a0424db9")]
+    [EnsureOriginal("9e4488d4")]
     // ReSharper disable once InconsistentNaming
     public static class MyProjectorBase_CanBuild
     {

--- a/MultigridProjectorClient/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorClient/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.3.3.0")]
-[assembly: AssemblyFileVersion("0.3.3.0")]
+[assembly: AssemblyVersion("0.3.4.0")]
+[assembly: AssemblyFileVersion("0.3.4.0")]

--- a/MultigridProjectorDedicated/Patches/MyProjectorBase_BuildInternal.cs
+++ b/MultigridProjectorDedicated/Patches/MyProjectorBase_BuildInternal.cs
@@ -12,7 +12,7 @@ namespace MultigridProjectorClient.Patches
     // ReSharper disable once UnusedType.Global
     [HarmonyPatch(typeof(MyProjectorBase))]
     [HarmonyPatch("BuildInternal")]
-    [EnsureOriginal("b5ce7ac2")]
+    [EnsureOriginal("55ff55cf")]
     // ReSharper disable once InconsistentNaming
     public static class MyProjectorBase_BuildInternal
     {

--- a/MultigridProjectorDedicated/Patches/MyProjectorBase_CanBuild.cs
+++ b/MultigridProjectorDedicated/Patches/MyProjectorBase_CanBuild.cs
@@ -11,7 +11,7 @@ namespace MultigridProjector.Patches
     // ReSharper disable once UnusedType.Global
     [HarmonyPatch(typeof(MyProjectorBase))]
     [HarmonyPatch("CanBuild", typeof(MySlimBlock), typeof(bool))]
-    [EnsureOriginal("a0424db9")]
+    [EnsureOriginal("9e4488d4")]
     // ReSharper disable once InconsistentNaming
     public static class MyProjectorBase_CanBuild
     {

--- a/MultigridProjectorDedicated/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorDedicated/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.3.3.0")]
-[assembly: AssemblyFileVersion("0.3.3.0")]
+[assembly: AssemblyVersion("0.3.4.0")]
+[assembly: AssemblyFileVersion("0.3.4.0")]

--- a/MultigridProjectorDedicated/manifest.xml
+++ b/MultigridProjectorDedicated/manifest.xml
@@ -3,5 +3,5 @@
   <Name>Multigrid Projector</Name>
   <Guid>d4f47dcb-9c07-4c1a-bc8c-ce42e87683ee</Guid>
   <Repository>MultigridProjectorDedicated</Repository>
-  <Version>v0.3.3</Version>
+  <Version>v0.3.4</Version>
 </PluginManifest>

--- a/MultigridProjectorModApiTest/Mod/metadata.mod
+++ b/MultigridProjectorModApiTest/Mod/metadata.mod
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ModMetadata xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <ModVersion>0.3.3</ModVersion>
+  <ModVersion>0.3.4</ModVersion>
 </ModMetadata>

--- a/MultigridProjectorModApiTest/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorModApiTest/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.3.3.0")]
-[assembly: AssemblyFileVersion("0.3.3.0")]
+[assembly: AssemblyVersion("0.3.4.0")]
+[assembly: AssemblyFileVersion("0.3.4.0")]

--- a/MultigridProjectorServer/MultigridProjectorServer.csproj
+++ b/MultigridProjectorServer/MultigridProjectorServer.csproj
@@ -61,14 +61,14 @@
         <Reference Include="System.Core" />
         <Reference Include="System.Data" />
         <Reference Include="System.Xml" />
-        <Reference Include="Torch, Version=1.3.1.147, Culture=neutral, PublicKeyToken=null">
-          <HintPath>$(SolutionDir)\TorchDir\Torch.dll</HintPath>
+        <Reference Include="Torch, Version=1.3.1.148, Culture=neutral, PublicKeyToken=null">
+          <HintPath>..\TorchDir\Torch.dll</HintPath>
         </Reference>
-        <Reference Include="Torch.API, Version=1.3.1.147, Culture=neutral, PublicKeyToken=null">
-          <HintPath>$(SolutionDir)\TorchDir\Torch.API.dll</HintPath>
+        <Reference Include="Torch.API, Version=1.3.1.148, Culture=neutral, PublicKeyToken=null">
+          <HintPath>..\TorchDir\Torch.API.dll</HintPath>
         </Reference>
-        <Reference Include="Torch.Server, Version=1.3.1.147, Culture=neutral, PublicKeyToken=null">
-          <HintPath>$(SolutionDir)\TorchDir\Torch.Server.exe</HintPath>
+        <Reference Include="Torch.Server, Version=1.3.1.148, Culture=neutral, PublicKeyToken=null">
+          <HintPath>..\TorchDir\Torch.Server.exe</HintPath>
         </Reference>
         <Reference Include="VRage, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
           <HintPath>$(SolutionDir)\TorchDir\DedicatedServer64\VRage.dll</HintPath>

--- a/MultigridProjectorServer/Patches/MyProjectorBase_BuildInternal.cs
+++ b/MultigridProjectorServer/Patches/MyProjectorBase_BuildInternal.cs
@@ -9,7 +9,7 @@ using VRageMath;
 namespace MultigridProjectorServer.Patches
 {
     [PatchShim]
-    [EnsureOriginalTorch(typeof(MyProjectorBase), "BuildInternal", null,"b5ce7ac2")]
+    [EnsureOriginalTorch(typeof(MyProjectorBase), "BuildInternal", null,"55ff55cf")]
     // ReSharper disable once InconsistentNaming
     // ReSharper disable once UnusedType.Global
     public static class MyProjectorBase_BuildInternal

--- a/MultigridProjectorServer/Patches/MyProjectorBase_CanBuild.cs
+++ b/MultigridProjectorServer/Patches/MyProjectorBase_CanBuild.cs
@@ -10,7 +10,7 @@ using Torch.Managers.PatchManager;
 namespace MultigridProjectorServer.Patches
 {
     [PatchShim]
-    [EnsureOriginalTorch(typeof(MyProjectorBase), "CanBuild", new []{typeof(MySlimBlock), typeof(bool)}, "a0424db9")]
+    [EnsureOriginalTorch(typeof(MyProjectorBase), "CanBuild", new []{typeof(MySlimBlock), typeof(bool)}, "9e4488d4")]
     // ReSharper disable once InconsistentNaming
     // ReSharper disable once UnusedType.Global
     public static class MyProjectorBase_CanBuild

--- a/MultigridProjectorServer/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorServer/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.3.3.0")]
-[assembly: AssemblyFileVersion("0.3.3.0")]
+[assembly: AssemblyVersion("0.3.4.0")]
+[assembly: AssemblyFileVersion("0.3.4.0")]

--- a/MultigridProjectorServer/manifest.xml
+++ b/MultigridProjectorServer/manifest.xml
@@ -3,5 +3,5 @@
   <Name>Multigrid Projector</Name>
   <Guid>d9359ba0-9a69-41c3-971d-eb5170adb97e</Guid>
   <Repository>MultigridProjectorServer</Repository>
-  <Version>v0.3.3</Version>
+  <Version>v0.3.4</Version>
 </PluginManifest>


### PR DESCRIPTION
0.3.4
- Compatibility with game version 1.198.024
- Fixed unweldable subgrid after grid split
- Fixed subgrid block statistics (projector Detailed Info)
- Referencing Torch 148 hotfix for game version 1.198.024
- Using the STABLE preprocessor directive to prevent building the mod usage warning into the client plugin if used from the GitHub source