### PR TITLE
Bugfix/0.4.1

### DIFF
--- a/MultigridProjector/Api/BlockLocation.cs
+++ b/MultigridProjector/Api/BlockLocation.cs
@@ -12,5 +12,10 @@ namespace MultigridProjector.Api
             GridIndex = gridIndex;
             Position = position;
         }
+
+        public override int GetHashCode()
+        {
+            return (((((GridIndex * 397) ^ Position.X) * 397) ^ Position.Y) * 397) ^ Position.Z;
+        }
     }
 }

--- a/MultigridProjector/Api/IMultigridProjectorApi.cs
+++ b/MultigridProjector/Api/IMultigridProjectorApi.cs
@@ -7,7 +7,7 @@ namespace MultigridProjector.Api
 {
     public interface IMultigridProjectorApi
     {
-        // Multigrid Projector version: 0.4.0
+        // Multigrid Projector version: 0.4.1
         string Version { get; }
 
         // Returns the number of subgrids in the active projection, returns zero if there is no projection

--- a/MultigridProjector/Api/Program.cs
+++ b/MultigridProjector/Api/Program.cs
@@ -162,6 +162,11 @@ namespace MultigridProjector.Api
                 GridIndex = gridIndex;
                 Position = position;
             }
+
+            public override int GetHashCode()
+            {
+                return (((((GridIndex * 397) ^ Position.X) * 397) ^ Position.Y) * 397) ^ Position.Z;
+            }
         }
 
         public enum BlockState

--- a/MultigridProjector/Logic/BlockMinLocation.cs
+++ b/MultigridProjector/Logic/BlockMinLocation.cs
@@ -12,5 +12,10 @@ namespace MultigridProjector.Logic
             GridIndex = gridIndex;
             MinPosition = minPosition;
         }
+
+        public override int GetHashCode()
+        {
+            return (((((GridIndex * 397) ^ MinPosition.X) * 397) ^ MinPosition.Y) * 397) ^ MinPosition.Z;
+        }
     }
 }

--- a/MultigridProjector/Logic/MultigridProjectorApiProvider.cs
+++ b/MultigridProjector/Logic/MultigridProjectorApiProvider.cs
@@ -18,7 +18,7 @@ namespace MultigridProjector.Logic
         private static MultigridProjectorApiProvider api;
         public static IMultigridProjectorApi Api => api ?? (api = new MultigridProjectorApiProvider());
 
-        public string Version => "0.4.0";
+        public string Version => "0.4.1";
 
         public int GetSubgridCount(long projectorId)
         {

--- a/MultigridProjector/Logic/Subgrid.cs
+++ b/MultigridProjector/Logic/Subgrid.cs
@@ -495,7 +495,12 @@ namespace MultigridProjector.Logic
         [Everywhere]
         private void OnGridSplit(MyCubeGrid grid1, MyCubeGrid grid2)
         {
+            var builtGrid = BuiltGrid;
+
             UnregisterBuiltGrid();
+
+            if (IsConnectedToProjector)
+                RegisterBuiltGrid(builtGrid);
         }
 
         [Everywhere]

--- a/MultigridProjector/MultigridProjector.projitems
+++ b/MultigridProjector/MultigridProjector.projitems
@@ -51,7 +51,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Logic\Connection.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.0.4.0, Culture=neutral, PublicKeyToken=null">
+    <Reference Include="0Harmony, Version=2.0.4.1, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\packages\Lib.Harmony.2.0.4\lib\net472\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Sandbox.Game, Version=0.1.1.0, Culture=neutral, PublicKeyToken=null">

--- a/MultigridProjector/MultigridProjector.projitems
+++ b/MultigridProjector/MultigridProjector.projitems
@@ -51,9 +51,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Logic\Connection.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.0.4.1, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\Lib.Harmony.2.0.4\lib\net472\0Harmony.dll</HintPath>
-    </Reference>
     <Reference Include="Sandbox.Game, Version=0.1.1.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Bin64\Sandbox.Game.dll</HintPath>
     </Reference>

--- a/MultigridProjectorClient/Mod/metadata.mod
+++ b/MultigridProjectorClient/Mod/metadata.mod
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ModMetadata xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <ModVersion>0.4.0</ModVersion>
+  <ModVersion>0.4.1</ModVersion>
 </ModMetadata>

--- a/MultigridProjectorClient/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorClient/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.0.0")]
-[assembly: AssemblyFileVersion("0.4.0.0")]
+[assembly: AssemblyVersion("0.4.1.0")]
+[assembly: AssemblyFileVersion("0.4.1.0")]

--- a/MultigridProjectorClient/steam_description.txt
+++ b/MultigridProjectorClient/steam_description.txt
@@ -35,6 +35,7 @@ After enabling the plugin it will be active for all single player worlds you loa
 [*] [url=https://steamcommunity.com/sharedfiles/filedetails/?id=2420963329]Test world[/url]
 [*] [url=https://github.com/viktor-ferenczi/multigrid-projector]Source code[/url]
 [*] [url=https://steamcommunity.com/sharedfiles/filedetails/?id=2433810091]Mod API Test[/url]
+[*] [url=https://steamcommunity.com/sharedfiles/filedetails/?id=2471605159]Programmable block API[/url]
 [*] [url=https://discord.gg/x3Z8Ug5YkQ]Bug reports[/url]
 [/list]
 Please vote on the bug ticket to get multigrid welding into the vanilla game, eventually:

--- a/MultigridProjectorDedicated/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorDedicated/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.0.0")]
-[assembly: AssemblyFileVersion("0.4.0.0")]
+[assembly: AssemblyVersion("0.4.1.0")]
+[assembly: AssemblyFileVersion("0.4.1.0")]

--- a/MultigridProjectorDedicated/manifest.xml
+++ b/MultigridProjectorDedicated/manifest.xml
@@ -3,5 +3,5 @@
   <Name>Multigrid Projector</Name>
   <Guid>d4f47dcb-9c07-4c1a-bc8c-ce42e87683ee</Guid>
   <Repository>MultigridProjectorDedicated</Repository>
-  <Version>v0.4.0</Version>
+  <Version>v0.4.1</Version>
 </PluginManifest>

--- a/MultigridProjectorModApiTest/Mod/metadata.mod
+++ b/MultigridProjectorModApiTest/Mod/metadata.mod
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ModMetadata xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <ModVersion>0.4.0</ModVersion>
+  <ModVersion>0.4.1</ModVersion>
 </ModMetadata>

--- a/MultigridProjectorModApiTest/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorModApiTest/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.0.0")]
-[assembly: AssemblyFileVersion("0.4.0.0")]
+[assembly: AssemblyVersion("0.4.1.0")]
+[assembly: AssemblyFileVersion("0.4.1.0")]

--- a/MultigridProjectorServer/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorServer/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.0.0")]
-[assembly: AssemblyFileVersion("0.4.0.0")]
+[assembly: AssemblyVersion("0.4.1.0")]
+[assembly: AssemblyFileVersion("0.4.1.0")]

--- a/MultigridProjectorServer/manifest.xml
+++ b/MultigridProjectorServer/manifest.xml
@@ -3,5 +3,5 @@
   <Name>Multigrid Projector</Name>
   <Guid>d9359ba0-9a69-41c3-971d-eb5170adb97e</Guid>
   <Repository>MultigridProjectorServer</Repository>
-  <Version>v0.4.0</Version>
+  <Version>v0.4.1</Version>
 </PluginManifest>

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ After enabling the plugin it will be active for all single player worlds you loa
 - [Torch plugin](https://torchapi.net/plugins/item/d9359ba0-9a69-41c3-971d-eb5170adb97e)
 - [Test world](https://steamcommunity.com/sharedfiles/filedetails/?id=2420963329)
 - [Source code](https://github.com/viktor-ferenczi/multigrid-projector)
+- [Mod API Test](https://steamcommunity.com/sharedfiles/filedetails/?id=2433810091)
+- [Programmable block API](https://steamcommunity.com/sharedfiles/filedetails/?id=2471605159)
 - [Bug reports](https://discord.gg/x3Z8Ug5YkQ)
 
 Please support me if you would like to receive regular updates to this client plugin as new game versions are released.


### PR DESCRIPTION
- Fixed broken projector state after grid split event on the main grid (grinding down part of it, missile release with merge block, etc.)
- Proper hash codes for block locations, so it is performant to use them as a dictionary key.
- Documentation changes