### PR TITLE
Bugfix/0.4.5

### DIFF
--- a/MultigridProjector/Api/IMultigridProjectorApi.cs
+++ b/MultigridProjector/Api/IMultigridProjectorApi.cs
@@ -7,7 +7,7 @@ namespace MultigridProjector.Api
 {
     public interface IMultigridProjectorApi
     {
-        // Multigrid Projector version: 0.4.4
+        // Multigrid Projector version: 0.4.5
         string Version { get; }
 
         // Returns the number of subgrids in the active projection, returns zero if there is no projection

--- a/MultigridProjector/Logic/MultigridProjection.cs
+++ b/MultigridProjector/Logic/MultigridProjection.cs
@@ -156,7 +156,7 @@ namespace MultigridProjector.Logic
             AutoAlignBlueprint();
         }
 
-        public void Destroy()
+        private void Destroy()
         {
             using (Projections.Write())
                 if (!Projections.Remove(Projector.EntityId))
@@ -707,6 +707,7 @@ namespace MultigridProjector.Logic
                             subgrid.PreviewGrid.PositionComp.SetWorldMatrix(ref wm, skipTeleportCheck: true);
                             subgrid.Positioned = true;
                             gridsToPosition--;
+                            // ReSharper disable once RedundantJumpStatement
                             continue;
                         }
                     }

--- a/MultigridProjector/Logic/MultigridProjection.cs
+++ b/MultigridProjector/Logic/MultigridProjection.cs
@@ -1611,12 +1611,6 @@ System.NullReferenceException: Object reference not set to an instance of an obj
             if (projector.CubeGrid == null || !projector.AllowWelding)
                 return;
 
-            // Projected projector?
-            // Prevents ghost subgrids in case of blueprints with nested projections.
-            // NOTE: projector.CubeGrid.IsPreview is still false, so don't depend on that!
-            if (projector.Physics == null)
-                return;
-
             if (!(objectBuilder is MyObjectBuilder_ProjectorBase projectorBuilder))
                 return;
 

--- a/MultigridProjector/Logic/MultigridProjectorApiProvider.cs
+++ b/MultigridProjector/Logic/MultigridProjectorApiProvider.cs
@@ -18,7 +18,7 @@ namespace MultigridProjector.Logic
         private static MultigridProjectorApiProvider api;
         public static IMultigridProjectorApi Api => api ?? (api = new MultigridProjectorApiProvider());
 
-        public string Version => "0.4.4";
+        public string Version => "0.4.5";
 
         public int GetSubgridCount(long projectorId)
         {

--- a/MultigridProjector/Logic/MultigridUpdateWork.cs
+++ b/MultigridProjector/Logic/MultigridUpdateWork.cs
@@ -41,10 +41,14 @@ namespace MultigridProjector.Logic
         {
             Cancel();
 
-            if (!IsComplete)
-            {
-                task.Wait(true);
-            }
+            // Caused freeze on two hosted Torch servers 3 times, as reporter by Babyboarder.
+            // Experimenting with just letting the background task fail (if any is running),
+            // which is better than a complete server lock-up.
+            //
+            // if (!IsComplete)
+            // {
+            //     task.Wait(true);
+            // }
 
             projection = null;
         }

--- a/MultigridProjector/Logic/MultigridUpdateWork.cs
+++ b/MultigridProjector/Logic/MultigridUpdateWork.cs
@@ -41,7 +41,7 @@ namespace MultigridProjector.Logic
         {
             Cancel();
 
-            if (!task.IsComplete)
+            if (!IsComplete)
             {
                 task.Wait(true);
             }
@@ -85,7 +85,7 @@ namespace MultigridProjector.Logic
             allGridsProcessed = !ShouldStop;
         }
 
-        private void UpdateBlockStatesAndCollectStatistics(WorkData workData = null)
+        private void UpdateBlockStatesAndCollectStatistics()
         {
             SubgridsScanned = 0;
             BlocksScanned = 0;

--- a/MultigridProjectorClient/Mod/metadata.mod
+++ b/MultigridProjectorClient/Mod/metadata.mod
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ModMetadata xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <ModVersion>0.4.4</ModVersion>
+  <ModVersion>0.4.5</ModVersion>
 </ModMetadata>

--- a/MultigridProjectorClient/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorClient/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.4.0")]
-[assembly: AssemblyFileVersion("0.4.4.0")]
+[assembly: AssemblyVersion("0.4.5.0")]
+[assembly: AssemblyFileVersion("0.4.5.0")]

--- a/MultigridProjectorClient/steam_description.txt
+++ b/MultigridProjectorClient/steam_description.txt
@@ -64,6 +64,8 @@ Thank you and enjoy!
 - opesoorry
 - jiringgot
 - N CG
+- mkaito
+- Johan F.
 - NeVaR
 - Jimbo
 

--- a/MultigridProjectorDedicated/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorDedicated/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.4.0")]
-[assembly: AssemblyFileVersion("0.4.4.0")]
+[assembly: AssemblyVersion("0.4.5.0")]
+[assembly: AssemblyFileVersion("0.4.5.0")]

--- a/MultigridProjectorMods/ApiTest/metadata.mod
+++ b/MultigridProjectorMods/ApiTest/metadata.mod
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ModMetadata xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <ModVersion>0.4.4</ModVersion>
+  <ModVersion>0.4.5</ModVersion>
 </ModMetadata>

--- a/MultigridProjectorMods/Extra/metadata.mod
+++ b/MultigridProjectorMods/Extra/metadata.mod
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ModMetadata xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <ModVersion>0.4.4</ModVersion>
+  <ModVersion>0.4.5</ModVersion>
 </ModMetadata>

--- a/MultigridProjectorMods/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorMods/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.4.0")]
-[assembly: AssemblyFileVersion("0.4.4.0")]
+[assembly: AssemblyVersion("0.4.5.0")]
+[assembly: AssemblyFileVersion("0.4.5.0")]

--- a/MultigridProjectorServer/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorServer/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.4.0")]
-[assembly: AssemblyFileVersion("0.4.4.0")]
+[assembly: AssemblyVersion("0.4.5.0")]
+[assembly: AssemblyFileVersion("0.4.5.0")]


### PR DESCRIPTION
0.4.5

- Fixed Torch server dropping players on trying to weld a projection loaded before the previous server restart. It was caused by the ghost projection fix, which seems to be unnecessary now based on testing. Releasing the change on the client side for consistency.

- Attempting a fix for the Torch server freeze happened rarely (3 times in total) when the Essentials plugin issued an AutoCommand to disable all projectors before saving the game: !blocks off type Projector