### PR TITLE
Bugfix/0.4.6

### DIFF
--- a/MultigridProjector/Api/IMultigridProjectorApi.cs
+++ b/MultigridProjector/Api/IMultigridProjectorApi.cs
@@ -7,7 +7,7 @@ namespace MultigridProjector.Api
 {
     public interface IMultigridProjectorApi
     {
-        // Multigrid Projector version: 0.4.5
+        // Multigrid Projector version: 0.4.6
         string Version { get; }
 
         // Returns the number of subgrids in the active projection, returns zero if there is no projection

--- a/MultigridProjector/Logic/MultigridProjection.cs
+++ b/MultigridProjector/Logic/MultigridProjection.cs
@@ -48,6 +48,8 @@ namespace MultigridProjector.Logic
 
         // Subgrids of the projection, associated built grids as they appear, block status information, statistics
         public readonly List<Subgrid> Subgrids = new List<Subgrid>();
+
+        // Subgrids supported for welding from projection, skips grids connected via connector (ships, missiles)
         public IEnumerable<Subgrid> SupportedSubgrids => Subgrids.Where(s => s.Supported);
 
         // Bidirectional mapping of corresponding base and top blocks by their grid index and min cube positions

--- a/MultigridProjector/Logic/MultigridProjectorApiProvider.cs
+++ b/MultigridProjector/Logic/MultigridProjectorApiProvider.cs
@@ -18,7 +18,7 @@ namespace MultigridProjector.Logic
         private static MultigridProjectorApiProvider api;
         public static IMultigridProjectorApi Api => api ?? (api = new MultigridProjectorApiProvider());
 
-        public string Version => "0.4.5";
+        public string Version => "0.4.6";
 
         public int GetSubgridCount(long projectorId)
         {

--- a/MultigridProjectorClient/Mod/metadata.mod
+++ b/MultigridProjectorClient/Mod/metadata.mod
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ModMetadata xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <ModVersion>0.4.5</ModVersion>
+  <ModVersion>0.4.6</ModVersion>
 </ModMetadata>

--- a/MultigridProjectorClient/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorClient/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.5.0")]
-[assembly: AssemblyFileVersion("0.4.5.0")]
+[assembly: AssemblyVersion("0.4.6.0")]
+[assembly: AssemblyFileVersion("0.4.6.0")]

--- a/MultigridProjectorDedicated/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorDedicated/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.5.0")]
-[assembly: AssemblyFileVersion("0.4.5.0")]
+[assembly: AssemblyVersion("0.4.6.0")]
+[assembly: AssemblyFileVersion("0.4.6.0")]

--- a/MultigridProjectorDedicated/manifest.xml
+++ b/MultigridProjectorDedicated/manifest.xml
@@ -3,5 +3,5 @@
   <Name>Multigrid Projector</Name>
   <Guid>d4f47dcb-9c07-4c1a-bc8c-ce42e87683ee</Guid>
   <Repository>MultigridProjectorDedicated</Repository>
-  <Version>v0.4.5</Version>
+  <Version>v0.4.6</Version>
 </PluginManifest>

--- a/MultigridProjectorMods/ApiTest/metadata.mod
+++ b/MultigridProjectorMods/ApiTest/metadata.mod
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ModMetadata xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <ModVersion>0.4.5</ModVersion>
+  <ModVersion>0.4.6</ModVersion>
 </ModMetadata>

--- a/MultigridProjectorMods/Extra/metadata.mod
+++ b/MultigridProjectorMods/Extra/metadata.mod
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ModMetadata xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <ModVersion>0.4.5</ModVersion>
+  <ModVersion>0.4.6</ModVersion>
 </ModMetadata>

--- a/MultigridProjectorMods/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorMods/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.5.0")]
-[assembly: AssemblyFileVersion("0.4.5.0")]
+[assembly: AssemblyVersion("0.4.6.0")]
+[assembly: AssemblyFileVersion("0.4.6.0")]

--- a/MultigridProjectorServer/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorServer/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.5.0")]
-[assembly: AssemblyFileVersion("0.4.5.0")]
+[assembly: AssemblyVersion("0.4.6.0")]
+[assembly: AssemblyFileVersion("0.4.6.0")]

--- a/MultigridProjectorServer/manifest.xml
+++ b/MultigridProjectorServer/manifest.xml
@@ -3,5 +3,5 @@
   <Name>Multigrid Projector</Name>
   <Guid>d9359ba0-9a69-41c3-971d-eb5170adb97e</Guid>
   <Repository>MultigridProjectorServer</Repository>
-  <Version>v0.4.5</Version>
+  <Version>v0.4.6</Version>
 </PluginManifest>


### PR DESCRIPTION
0.4.6: Proper fix for canceling the background worker scanning the projection on disabling projectors. There should be no more ERRORs in the log and no rare freezes anymore.