### PR TITLE
Bugfix/0.4.11

### DIFF
--- a/MultigridProjector/Api/IMultigridProjectorApi.cs
+++ b/MultigridProjector/Api/IMultigridProjectorApi.cs
@@ -7,7 +7,7 @@ namespace MultigridProjector.Api
 {
     public interface IMultigridProjectorApi
     {
-        // Multigrid Projector version: 0.4.10
+        // Multigrid Projector version: 0.4.11
         string Version { get; }
 
         // Returns the number of subgrids in the active projection, returns zero if there is no projection

--- a/MultigridProjector/Logic/MultigridProjectorApiProvider.cs
+++ b/MultigridProjector/Logic/MultigridProjectorApiProvider.cs
@@ -18,7 +18,7 @@ namespace MultigridProjector.Logic
         private static MultigridProjectorApiProvider api;
         public static IMultigridProjectorApi Api => api ?? (api = new MultigridProjectorApiProvider());
 
-        public string Version => "0.4.10";
+        public string Version => "0.4.11";
 
         public int GetSubgridCount(long projectorId)
         {

--- a/MultigridProjector/Logic/Subgrid.cs
+++ b/MultigridProjector/Logic/Subgrid.cs
@@ -598,8 +598,11 @@ namespace MultigridProjector.Logic
 
             // Add block to named groups
             var position = PreviewGrid.WorldToGridInteger(terminalBlock.SlimBlock.WorldPosition);
-            foreach (var blockGroup in GridBuilder.BlockGroups.Where(blockGroup => blockGroup.Blocks.Contains(position)))
+            foreach (var blockGroup in GridBuilder.BlockGroups)
             {
+                if (!blockGroup.Blocks.Contains(position))
+                    continue;
+
                 var newBlockGroup = MyBlockGroupExtensions.NewBlockGroup(blockGroup.Name);
                 newBlockGroup.GetTerminalBlocks().Add(terminalBlock);
                 terminalBlock.CubeGrid.AddGroup(newBlockGroup);

--- a/MultigridProjector/MultigridProjector.shproj
+++ b/MultigridProjector/MultigridProjector.shproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup Label="Globals">
         <ProjectGuid>{EB280DCD-171D-4764-912F-AF7C99153BB4}</ProjectGuid>
-        <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+        <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     </PropertyGroup>
     <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
     <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />

--- a/MultigridProjectorClient/Mod/metadata.mod
+++ b/MultigridProjectorClient/Mod/metadata.mod
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ModMetadata xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <ModVersion>0.4.10</ModVersion>
+  <ModVersion>0.4.11</ModVersion>
 </ModMetadata>

--- a/MultigridProjectorClient/MultigridProjectorClient.csproj
+++ b/MultigridProjectorClient/MultigridProjectorClient.csproj
@@ -11,7 +11,7 @@
         <AssemblyName>MultigridProjectorClient</AssemblyName>
         <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
         <FileAlignment>512</FileAlignment>
-        <LangVersion>default</LangVersion>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
         <PlatformTarget>x64</PlatformTarget>

--- a/MultigridProjectorClient/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorClient/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.10.0")]
-[assembly: AssemblyFileVersion("0.4.10.0")]
+[assembly: AssemblyVersion("0.4.11.0")]
+[assembly: AssemblyFileVersion("0.4.11.0")]

--- a/MultigridProjectorDedicated/MultigridProjectorDedicated.csproj
+++ b/MultigridProjectorDedicated/MultigridProjectorDedicated.csproj
@@ -11,7 +11,7 @@
         <AssemblyName>MultigridProjectorDedicated</AssemblyName>
         <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
         <FileAlignment>512</FileAlignment>
-        <LangVersion>default</LangVersion>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
         <PlatformTarget>x64</PlatformTarget>

--- a/MultigridProjectorDedicated/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorDedicated/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.10.0")]
-[assembly: AssemblyFileVersion("0.4.10.0")]
+[assembly: AssemblyVersion("0.4.11.0")]
+[assembly: AssemblyFileVersion("0.4.11.0")]

--- a/MultigridProjectorDedicated/manifest.xml
+++ b/MultigridProjectorDedicated/manifest.xml
@@ -3,5 +3,5 @@
   <Name>Multigrid Projector</Name>
   <Guid>d4f47dcb-9c07-4c1a-bc8c-ce42e87683ee</Guid>
   <Repository>MultigridProjectorDedicated</Repository>
-  <Version>v0.4.10</Version>
+  <Version>v0.4.11</Version>
 </PluginManifest>

--- a/MultigridProjectorMods/ApiTest/metadata.mod
+++ b/MultigridProjectorMods/ApiTest/metadata.mod
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ModMetadata xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <ModVersion>0.4.10</ModVersion>
+  <ModVersion>0.4.11</ModVersion>
 </ModMetadata>

--- a/MultigridProjectorMods/Extra/metadata.mod
+++ b/MultigridProjectorMods/Extra/metadata.mod
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ModMetadata xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <ModVersion>0.4.10</ModVersion>
+  <ModVersion>0.4.11</ModVersion>
 </ModMetadata>

--- a/MultigridProjectorMods/MultigridProjectorMods.csproj
+++ b/MultigridProjectorMods/MultigridProjectorMods.csproj
@@ -11,7 +11,7 @@
         <AssemblyName>MultigridProjectorMods</AssemblyName>
         <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
         <FileAlignment>512</FileAlignment>
-        <LangVersion>default</LangVersion>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
         <PlatformTarget>x64</PlatformTarget>

--- a/MultigridProjectorMods/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorMods/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.10.0")]
-[assembly: AssemblyFileVersion("0.4.10.0")]
+[assembly: AssemblyVersion("0.4.11.0")]
+[assembly: AssemblyFileVersion("0.4.11.0")]

--- a/MultigridProjectorServer/MultigridProjectorServer.csproj
+++ b/MultigridProjectorServer/MultigridProjectorServer.csproj
@@ -11,7 +11,7 @@
         <AssemblyName>MultigridProjectorServer</AssemblyName>
         <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
         <FileAlignment>512</FileAlignment>
-        <LangVersion>default</LangVersion>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
         <PlatformTarget>x64</PlatformTarget>

--- a/MultigridProjectorServer/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorServer/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.10.0")]
-[assembly: AssemblyFileVersion("0.4.10.0")]
+[assembly: AssemblyVersion("0.4.11.0")]
+[assembly: AssemblyFileVersion("0.4.11.0")]

--- a/MultigridProjectorServer/manifest.xml
+++ b/MultigridProjectorServer/manifest.xml
@@ -3,5 +3,5 @@
   <Name>Multigrid Projector</Name>
   <Guid>d9359ba0-9a69-41c3-971d-eb5170adb97e</Guid>
   <Repository>MultigridProjectorServer</Repository>
-  <Version>v0.4.10</Version>
+  <Version>v0.4.11</Version>
 </PluginManifest>


### PR DESCRIPTION
0.4.11: Fixed compatibility with the Plant and Cook mod 

The Kitchen block caused overlapping blocks with the same grid position, which prevented the projector from loading such a blueprint.

Reduced memory allocations and CPU load of hand welding. 

Not using LINQ in performance critical code.