### PR TITLE
Bugfix/0.4.12

### DIFF
--- a/MultigridProjector/Api/IMultigridProjectorApi.cs
+++ b/MultigridProjector/Api/IMultigridProjectorApi.cs
@@ -7,7 +7,7 @@ namespace MultigridProjector.Api
 {
     public interface IMultigridProjectorApi
     {
-        // Multigrid Projector version: 0.4.11
+        // Multigrid Projector version: 0.4.12
         string Version { get; }
 
         // Returns the number of subgrids in the active projection, returns zero if there is no projection

--- a/MultigridProjector/Extensions/MyProjectorBaseExtensions.cs
+++ b/MultigridProjector/Extensions/MyProjectorBaseExtensions.cs
@@ -297,7 +297,8 @@ namespace MultigridProjector.Extensions
                 return;
 
             // Consistent remapping of all grids to keep sub-grid relations intact
-            MyEntities.RemapObjectBuilderCollection(gridBuilders);
+            lock (gridBuilders)
+                MyEntities.RemapObjectBuilderCollection(gridBuilders);
         }
 
         public static bool AlignToRepairProjector(this MyProjectorBase projector, MyObjectBuilder_CubeGrid gridBuilder)

--- a/MultigridProjector/Logic/MultigridProjectorApiProvider.cs
+++ b/MultigridProjector/Logic/MultigridProjectorApiProvider.cs
@@ -18,7 +18,7 @@ namespace MultigridProjector.Logic
         private static MultigridProjectorApiProvider api;
         public static IMultigridProjectorApi Api => api ?? (api = new MultigridProjectorApiProvider());
 
-        public string Version => "0.4.11";
+        public string Version => "0.4.12";
 
         public int GetSubgridCount(long projectorId)
         {

--- a/MultigridProjector/Logic/Subgrid.cs
+++ b/MultigridProjector/Logic/Subgrid.cs
@@ -332,7 +332,8 @@ namespace MultigridProjector.Logic
             BuiltGrid.OnBlockIntegrityChanged += OnBlockIntegrityChangedWithErrorHandler;
             BuiltGrid.OnBlockAdded += OnBlockAddedWithErrorHandler;
             BuiltGrid.OnBlockRemoved += OnBlockRemovedWithErrorHandler;
-            BuiltGrid.OnGridSplit += OnGridSplitWithErrorHandler;
+            BuiltGrid.OnGridSplit += OnGridSplitOrMergeWithErrorHandler;
+            BuiltGrid.OnGridMerge += OnGridSplitOrMergeWithErrorHandler;
             BuiltGrid.OnClosing += OnGridClosingWithErrorHandler;
         }
 
@@ -341,7 +342,8 @@ namespace MultigridProjector.Logic
             BuiltGrid.OnBlockIntegrityChanged -= OnBlockIntegrityChangedWithErrorHandler;
             BuiltGrid.OnBlockAdded -= OnBlockAddedWithErrorHandler;
             BuiltGrid.OnBlockRemoved -= OnBlockRemovedWithErrorHandler;
-            BuiltGrid.OnGridSplit -= OnGridSplitWithErrorHandler;
+            BuiltGrid.OnGridSplit -= OnGridSplitOrMergeWithErrorHandler;
+            BuiltGrid.OnGridMerge -= OnGridSplitOrMergeWithErrorHandler;
             BuiltGrid.OnClosing -= OnGridClosingWithErrorHandler;
         }
 
@@ -385,11 +387,11 @@ namespace MultigridProjector.Logic
         }
 
         [Everywhere]
-        private void OnGridSplitWithErrorHandler(MyCubeGrid arg1, MyCubeGrid arg2)
+        private void OnGridSplitOrMergeWithErrorHandler(MyCubeGrid arg1, MyCubeGrid arg2)
         {
             try
             {
-                OnGridSplit(arg1, arg2);
+                OnGridSplitOrMerge(arg1, arg2);
             }
             catch (Exception e)
             {
@@ -512,7 +514,7 @@ namespace MultigridProjector.Logic
         }
 
         [Everywhere]
-        private void OnGridSplit(MyCubeGrid grid1, MyCubeGrid grid2)
+        private void OnGridSplitOrMerge(MyCubeGrid grid1, MyCubeGrid grid2)
         {
             var builtGrid = BuiltGrid;
 

--- a/MultigridProjectorClient/Mod/metadata.mod
+++ b/MultigridProjectorClient/Mod/metadata.mod
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ModMetadata xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <ModVersion>0.4.11</ModVersion>
+  <ModVersion>0.4.12</ModVersion>
 </ModMetadata>

--- a/MultigridProjectorClient/MultigridProjectorClient.csproj
+++ b/MultigridProjectorClient/MultigridProjectorClient.csproj
@@ -33,8 +33,8 @@
         <WarningLevel>4</WarningLevel>
     </PropertyGroup>
     <ItemGroup>
-        <Reference Include="0Harmony, Version=2.2.0.0, Culture=neutral, PublicKeyToken=null">
-          <HintPath>..\packages\Lib.Harmony.2.2.0\lib\net48\0Harmony.dll</HintPath>
+        <Reference Include="0Harmony, Version=2.2.1.0, Culture=neutral, PublicKeyToken=null">
+          <HintPath>..\packages\Lib.Harmony.2.2.1\lib\net48\0Harmony.dll</HintPath>
           <Private>True</Private>
         </Reference>
         <Reference Include="Sandbox.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">

--- a/MultigridProjectorClient/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorClient/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.11.0")]
-[assembly: AssemblyFileVersion("0.4.11.0")]
+[assembly: AssemblyVersion("0.4.12.0")]
+[assembly: AssemblyFileVersion("0.4.12.0")]

--- a/MultigridProjectorClient/steam_description.txt
+++ b/MultigridProjectorClient/steam_description.txt
@@ -21,7 +21,7 @@ After enabling the plugin it will be active for all single player worlds you loa
 
 [h2]Server plugins[/h2]
 [list]
-[*] [url=https://torchapi.net/plugins/item/d9359ba0-9a69-41c3-971d-eb5170adb97e]Torch Server[/url] (updated automatically by Torch)
+[*] [url=https://torchapi.com/plugins/view/?guid=d9359ba0-9a69-41c3-971d-eb5170adb97e]Torch Server[/url] (updated automatically by Torch)
 [*] [url=https://www.ferenczi.eu/se/multigrid-projector/]Dedicated Server[/url] (requires manual updating)
 [/list]
 
@@ -31,7 +31,7 @@ After enabling the plugin it will be active for all single player worlds you loa
 [list]
 [*] [url=https://discord.gg/PYPFPGf3Ca]SE Mods Discord[/url]
 [*] [url=https://www.youtube.com/channel/UCc5ar3cW9qoOgdBb1FM_rxQ]YouTube Channel[/url]
-[*] [url=https://torchapi.net/plugins/item/d9359ba0-9a69-41c3-971d-eb5170adb97e]Torch plugin[/url]
+[*] [url=https://torchapi.com/plugins/view/?guid=d9359ba0-9a69-41c3-971d-eb5170adb97e]Torch plugin[/url]
 [*] [url=https://steamcommunity.com/sharedfiles/filedetails/?id=2420963329]Test world[/url]
 [*] [url=https://github.com/viktor-ferenczi/multigrid-projector]Source code[/url]
 [*] [url=https://steamcommunity.com/sharedfiles/filedetails/?id=2433810091]Mod API Test[/url]

--- a/MultigridProjectorDedicated/MultigridProjectorDedicated.csproj
+++ b/MultigridProjectorDedicated/MultigridProjectorDedicated.csproj
@@ -111,7 +111,7 @@
       </Content>
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="Lib.Harmony" Version="2.2.0" />
+      <PackageReference Include="Lib.Harmony" Version="2.2.1" />
       <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     </ItemGroup>
     <ItemGroup>

--- a/MultigridProjectorDedicated/Patches/MyProjectorBase_CanBuild.cs
+++ b/MultigridProjectorDedicated/Patches/MyProjectorBase_CanBuild.cs
@@ -23,7 +23,7 @@ namespace MultigridProjector.Patches
             MySlimBlock projectedBlock,
             bool checkHavokIntersections,
             // ReSharper disable once InconsistentNaming
-            out BuildCheckResult __result)
+            ref BuildCheckResult __result)
         {
             var projector = __instance;
 

--- a/MultigridProjectorDedicated/Patches/MyProjectorBase_Remap.cs
+++ b/MultigridProjectorDedicated/Patches/MyProjectorBase_Remap.cs
@@ -31,6 +31,7 @@ namespace MultigridProjector.Patches
 
                 projector.RemapObjectBuilders();
                 
+                // Call patched SetNewBlueprint
                 var gridBuilders = projector.GetOriginalGridBuilders();
                 if (gridBuilders != null && gridBuilders.Count > 0)
                 {

--- a/MultigridProjectorDedicated/Patches/MyProjectorClipboard_UpdateGridTransformations.cs
+++ b/MultigridProjectorDedicated/Patches/MyProjectorClipboard_UpdateGridTransformations.cs
@@ -29,7 +29,7 @@ namespace MultigridProjector.Patches
                 if (!MultigridProjection.TryFindProjectionByProjector(projector, out var projection))
                     return true;
 
-                // Preview grid alignment is needed on server side as well, so it was moved into UpdateAfterSimulation
+                // Alignment is needed on server side as well, so it was moved into UpdateAfterSimulation
             }
             catch (Exception e)
             {

--- a/MultigridProjectorDedicated/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorDedicated/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.11.0")]
-[assembly: AssemblyFileVersion("0.4.11.0")]
+[assembly: AssemblyVersion("0.4.12.0")]
+[assembly: AssemblyFileVersion("0.4.12.0")]

--- a/MultigridProjectorDedicated/manifest.xml
+++ b/MultigridProjectorDedicated/manifest.xml
@@ -3,5 +3,5 @@
   <Name>Multigrid Projector</Name>
   <Guid>d4f47dcb-9c07-4c1a-bc8c-ce42e87683ee</Guid>
   <Repository>MultigridProjectorDedicated</Repository>
-  <Version>v0.4.11</Version>
+  <Version>v0.4.12</Version>
 </PluginManifest>

--- a/MultigridProjectorMods/ApiTest/metadata.mod
+++ b/MultigridProjectorMods/ApiTest/metadata.mod
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ModMetadata xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <ModVersion>0.4.11</ModVersion>
+  <ModVersion>0.4.12</ModVersion>
 </ModMetadata>

--- a/MultigridProjectorMods/Extra/metadata.mod
+++ b/MultigridProjectorMods/Extra/metadata.mod
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ModMetadata xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <ModVersion>0.4.11</ModVersion>
+  <ModVersion>0.4.12</ModVersion>
 </ModMetadata>

--- a/MultigridProjectorMods/MultigridProjectorMods.csproj
+++ b/MultigridProjectorMods/MultigridProjectorMods.csproj
@@ -33,8 +33,8 @@
         <WarningLevel>4</WarningLevel>
     </PropertyGroup>
     <ItemGroup>
-        <Reference Include="0Harmony, Version=2.2.0.0, Culture=neutral, PublicKeyToken=null">
-          <HintPath>..\packages\Lib.Harmony.2.2.0\lib\net48\0Harmony.dll</HintPath>
+        <Reference Include="0Harmony, Version=2.2.1.0, Culture=neutral, PublicKeyToken=null">
+          <HintPath>..\packages\Lib.Harmony.2.2.1\lib\net48\0Harmony.dll</HintPath>
           <Private>True</Private>
         </Reference>
         <Reference Include="System" />

--- a/MultigridProjectorMods/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorMods/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.11.0")]
-[assembly: AssemblyFileVersion("0.4.11.0")]
+[assembly: AssemblyVersion("0.4.12.0")]
+[assembly: AssemblyFileVersion("0.4.12.0")]

--- a/MultigridProjectorPrograms/MultigridProjectorPrograms.csproj
+++ b/MultigridProjectorPrograms/MultigridProjectorPrograms.csproj
@@ -108,7 +108,7 @@
         <Compile Include="Properties\AssemblyInfo.cs" />
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="Lib.Harmony" Version="2.2.0" />
+      <PackageReference Include="Lib.Harmony" Version="2.2.1" />
       <PackageReference Include="NUnit" Version="3.13.2" />
     </ItemGroup>
     <ItemGroup>

--- a/MultigridProjectorServer/MultigridProjectorServer.csproj
+++ b/MultigridProjectorServer/MultigridProjectorServer.csproj
@@ -61,13 +61,13 @@
         <Reference Include="System.Core" />
         <Reference Include="System.Data" />
         <Reference Include="System.Xml" />
-        <Reference Include="Torch, Version=1.3.1.153, Culture=neutral, PublicKeyToken=null">
+        <Reference Include="Torch, Version=1.3.1.175, Culture=neutral, PublicKeyToken=null">
           <HintPath>..\TorchDir\Torch.dll</HintPath>
         </Reference>
-        <Reference Include="Torch.API, Version=1.3.1.153, Culture=neutral, PublicKeyToken=null">
+        <Reference Include="Torch.API, Version=1.3.1.175, Culture=neutral, PublicKeyToken=null">
           <HintPath>..\TorchDir\Torch.API.dll</HintPath>
         </Reference>
-        <Reference Include="Torch.Server, Version=1.3.1.153, Culture=neutral, PublicKeyToken=null">
+        <Reference Include="Torch.Server, Version=1.3.1.175, Culture=neutral, PublicKeyToken=null">
           <HintPath>..\TorchDir\Torch.Server.exe</HintPath>
         </Reference>
         <Reference Include="VRage, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">

--- a/MultigridProjectorServer/MultigridProjectorServer.csproj
+++ b/MultigridProjectorServer/MultigridProjectorServer.csproj
@@ -123,7 +123,7 @@
       </Content>
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="Lib.Harmony" Version="2.2.0" />
+      <PackageReference Include="Lib.Harmony" Version="2.2.1" />
       <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     </ItemGroup>
     <ItemGroup>

--- a/MultigridProjectorServer/MultigridProjectorServer.csproj
+++ b/MultigridProjectorServer/MultigridProjectorServer.csproj
@@ -61,13 +61,13 @@
         <Reference Include="System.Core" />
         <Reference Include="System.Data" />
         <Reference Include="System.Xml" />
-        <Reference Include="Torch, Version=1.3.1.175, Culture=neutral, PublicKeyToken=null">
+        <Reference Include="Torch, Version=1.3.1.183, Culture=neutral, PublicKeyToken=null">
           <HintPath>..\TorchDir\Torch.dll</HintPath>
         </Reference>
-        <Reference Include="Torch.API, Version=1.3.1.175, Culture=neutral, PublicKeyToken=null">
+        <Reference Include="Torch.API, Version=1.3.1.183, Culture=neutral, PublicKeyToken=null">
           <HintPath>..\TorchDir\Torch.API.dll</HintPath>
         </Reference>
-        <Reference Include="Torch.Server, Version=1.3.1.175, Culture=neutral, PublicKeyToken=null">
+        <Reference Include="Torch.Server, Version=1.3.1.183, Culture=neutral, PublicKeyToken=null">
           <HintPath>..\TorchDir\Torch.Server.exe</HintPath>
         </Reference>
         <Reference Include="VRage, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">

--- a/MultigridProjectorServer/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorServer/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.11.0")]
-[assembly: AssemblyFileVersion("0.4.11.0")]
+[assembly: AssemblyVersion("0.4.12.0")]
+[assembly: AssemblyFileVersion("0.4.12.0")]

--- a/MultigridProjectorServer/manifest.xml
+++ b/MultigridProjectorServer/manifest.xml
@@ -3,5 +3,5 @@
   <Name>Multigrid Projector</Name>
   <Guid>d9359ba0-9a69-41c3-971d-eb5170adb97e</Guid>
   <Repository>MultigridProjectorServer</Repository>
-  <Version>v0.4.11</Version>
+  <Version>v0.4.12</Version>
 </PluginManifest>


### PR DESCRIPTION
0.4.12
- Harmony 2.2.1
- Torch 1.3.1.183
- Locking the list of grid builders while remapping or while depending on the EntityID mappings to be consistent (it is supposed to fix multiplayer subgrid weldability issues)
- Handling OnGridMerge
- Readme fixes