### PR TITLE
Bug fixes from testing

### DIFF
--- a/MultigridProjectorClient/Extra/ProjectorAligner.cs
+++ b/MultigridProjectorClient/Extra/ProjectorAligner.cs
@@ -250,6 +250,7 @@ namespace MultigridProjectorClient.Extra
         private void Release()
         {
             projector = null;
+            if (MyHud.Static == null) return;
             MyAPIGateway.Utilities.ShowMessage("Multigrid Projector", "Manual projection alignment cancelled");
         }
 

--- a/MultigridProjectorClient/PluginSession.cs
+++ b/MultigridProjectorClient/PluginSession.cs
@@ -4,6 +4,7 @@ using MultigridProjector.Utilities;
 using MultigridProjectorClient.Utilities;
 using MultigridProjectorClient.Extra;
 using Sandbox.Game.Gui;
+using Sandbox.Game.World;
 using VRage.Game;
 using VRage.Game.Components;
 
@@ -28,6 +29,8 @@ namespace MultigridProjectorClient
         {
             if (!MyTerminalControlFactory.AreControlsCreated<MySpaceProjector>())
             {
+                if (MySession.Static.IsUnloading) return; //prevent infinite loop since controls will not be created if they haven't been yet
+               
                 Events.InvokeOnGameThread(InitializeDialogs, frames: 1);
                 return;
             }


### PR DESCRIPTION
- Fixed infinite loop when unloading session if projector controls haven't been created
- Prevented NRE in ProjectorAligner.Release() when unloading Session