### PR TITLE
Fixed block highlight visibility in atmosphere

### DIFF
--- a/MultigridProjectorClient/Extra/BlockHighlight.cs
+++ b/MultigridProjectorClient/Extra/BlockHighlight.cs
@@ -162,7 +162,8 @@ namespace MultigridProjectorClient.Extra
                 1,
                 0.01f,
                 lineMaterial: material ?? MyStringId.GetOrCompute("ContainerBorder"),
-                blendType: MyBillboard.BlendTypeEnum.AdditiveTop);
+                blendType: MyBillboard.BlendTypeEnum.AdditiveTop,
+                intensity: 100);
         }
     }
 }


### PR DESCRIPTION
This fixes a bug in [BlockHighlight](https://github.com/viktor-ferenczi/multigrid-projector/blob/main/MultigridProjectorClient/Extra/BlockHighlight.cs) where the wireframe would not show in atmospheres due to a low default intensity. 