### PR TITLE
Add a Copy BoM button to CraftDialog

### DIFF
--- a/MultigridProjectorClient/Extra/CraftProjection.cs
+++ b/MultigridProjectorClient/Extra/CraftProjection.cs
@@ -55,6 +55,7 @@ namespace MultigridProjectorClient.Extra
             MyAssembler assembler = GetProductionAssembler();
 
             HashSet<MyGuiControlTable.Row> rows = new HashSet<MyGuiControlTable.Row>();
+            List<string> bomLines = new List<string>();
 
             Dictionary<MyDefinitionId, int> blueprintComponents = GetBlueprintComponents(projector);
             Dictionary<MyDefinitionId, int> inventoryComponents = GetInventoryComponents(projector.CubeGrid);
@@ -62,6 +63,8 @@ namespace MultigridProjectorClient.Extra
             Dictionary<MyDefinitionId, int> requiredComponents = new Dictionary<MyDefinitionId, int>(blueprintComponents);
             SubtractComponents(ref requiredComponents, inventoryComponents);
             ClampComponents(ref requiredComponents);
+            
+            const string idPrefix = "MyObjectBuilder_";
 
             foreach (KeyValuePair<MyDefinitionId, int> component in blueprintComponents)
             {
@@ -86,6 +89,13 @@ namespace MultigridProjectorClient.Extra
                 row.AddCell(new MyGuiControlTable.Cell(blueprintAmount.ToString("N0"), toolTip: blueprintToolTip, userData: blueprintAmount));
 
                 rows.Add(row);
+
+                var idStr = id.ToString();
+                if (idStr.StartsWith(idPrefix))
+                {
+                    idStr = idStr.Substring(idPrefix.Length);
+                }
+                bomLines.Add($"{idStr}={blueprintAmount}");
             }
 
             MyGuiScreenMessageBox dialog;
@@ -94,12 +104,13 @@ namespace MultigridProjectorClient.Extra
                 dialog = Menus.CraftDialog.CreateDialog(
                     assembler.DisplayNameText,
                     rows,
+                    bomLines,
                     (comp, amount) => SendToAssembler(assembler, new Dictionary<MyDefinitionId, int>() { { comp, amount } }),
                     SwitchToProductionTab);
             }
             else
             {
-                dialog = Menus.CraftDialog.CreateDialog("[None]", rows);
+                dialog = Menus.CraftDialog.CreateDialog("[None]", rows, bomLines);
             }
 
             MyGuiSandbox.AddScreen(dialog);


### PR DESCRIPTION
Requires #65 

Adds a button to the CraftDialog to copy a bill of materials to the clipboard, suitable for use with IIM Special containers, RIH, and many other inventory managers. Intended to help fill a welding skiff for a particular blueprint.

Sample:

```
Component/SteelPlate=140803
Component/Construction=34481
Component/LargeTube=8498
Component/Motor=10241
Component/Computer=17221
Component/SmallTube=11295
Component/RadioCommunication=120
Component/InteriorPlate=18603
Component/Superconductor=6680
Component/Reactor=36100
Component/MetalGrid=18655
Component/Girder=4417
Component/PDCComponent=480
Component/UpgradedBelterComponent=260
Component/Display=386
Component/AryxLynxon_FusionComponent=536
Component/PowerCell=9040
Component/Thrust=3040
Component/InnerComponent=120
Component/SolarCell=384
Component/BulletproofGlass=967
Component/GravityGenerator=667
Component/TrackingComponent=20
Component/BelterComponent=90
Component/HeavyMotor=400
Component/LithiumCell=960
Component/LidarComponent=1
Component/Medical=21
Component/GuidanceComponent=4
Component/MCRNComponent=15
```