### PR TITLE
0.6.2

### DIFF
--- a/.run/Plugin Loader Launcher.run.xml
+++ b/.run/Plugin Loader Launcher.run.xml
@@ -1,5 +1,5 @@
 ﻿<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Client" type="RunExe" factoryName=".NET Executable">
+  <configuration default="false" name="Plugin Loader Launcher" type="RunExe" factoryName=".NET Executable">
     <option name="EXE_PATH" value="$PROJECT_DIR$/../../../Program Files (x86)/Steam/steamapps/common/SpaceEngineers/Bin64/SpaceEngineersLauncher.exe" />
     <option name="PROGRAM_PARAMETERS" value="-skipintro" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/../../../Program Files (x86)/Steam/steamapps/common/SpaceEngineers/Bin64" />

--- a/IngameApiTest/IngameApiTest.csproj
+++ b/IngameApiTest/IngameApiTest.csproj
@@ -16,7 +16,7 @@
         <RunPostBuildEvent>Always</RunPostBuildEvent>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-        <PlatformTarget>AnyCPU</PlatformTarget>
+        <PlatformTarget>x64</PlatformTarget>
         <DebugSymbols>true</DebugSymbols>
         <DebugType>full</DebugType>
         <Optimize>false</Optimize>
@@ -26,7 +26,7 @@
         <WarningLevel>4</WarningLevel>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-        <PlatformTarget>AnyCPU</PlatformTarget>
+        <PlatformTarget>x64</PlatformTarget>
         <DebugType>pdbonly</DebugType>
         <Optimize>true</Optimize>
         <OutputPath>bin\Release\</OutputPath>

--- a/IngameApiTest/Properties/AssemblyInfo.cs
+++ b/IngameApiTest/Properties/AssemblyInfo.cs
@@ -4,12 +4,12 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("IngameApiTest")]
+[assembly: AssemblyTitle("MultigridProjectorMods")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("IngameApiTest")]
-[assembly: AssemblyCopyright("Copyright ©  2024")]
+[assembly: AssemblyProduct("MultigridProjectorMods")]
+[assembly: AssemblyCopyright("Copyright ©  2021")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -19,7 +19,7 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("6ADA9B77-C3EA-4BE1-81D9-56266CA71FD1")]
+[assembly: Guid("C91C0E2A-7076-40D8-89C6-B6B67EF3E0DD")]
 
 // Version information for an assembly consists of the following four values:
 //
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("0.6.2.0")]
+[assembly: AssemblyFileVersion("0.6.2.0")]

--- a/ModApiTest/Mod/metadata.mod
+++ b/ModApiTest/Mod/metadata.mod
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ModMetadata xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <ModVersion>0.6.0</ModVersion>
+  <ModVersion>0.6.2</ModVersion>
 </ModMetadata>

--- a/ModApiTest/ModApiTest.csproj
+++ b/ModApiTest/ModApiTest.csproj
@@ -15,7 +15,7 @@
         <RunPostBuildEvent>Always</RunPostBuildEvent>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-        <PlatformTarget>AnyCPU</PlatformTarget>
+        <PlatformTarget>x64</PlatformTarget>
         <DebugSymbols>true</DebugSymbols>
         <DebugType>full</DebugType>
         <Optimize>false</Optimize>
@@ -25,7 +25,7 @@
         <WarningLevel>4</WarningLevel>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-        <PlatformTarget>AnyCPU</PlatformTarget>
+        <PlatformTarget>x64</PlatformTarget>
         <DebugType>pdbonly</DebugType>
         <Optimize>true</Optimize>
         <OutputPath>bin\Release\</OutputPath>

--- a/MultigridProjector/Logic/MultigridProjection.cs
+++ b/MultigridProjector/Logic/MultigridProjection.cs
@@ -124,6 +124,7 @@ namespace MultigridProjector.Logic
 
         // Requests a remap operation on building the next functional (non-armor) block
         private bool requestRemap;
+        private bool remapRequested = true;
 
         // Controls when the plugin and Mod API can access projector information already
         internal bool IsValidForApi => Initialized && HasScanned;
@@ -549,8 +550,23 @@ namespace MultigridProjector.Logic
             AggregateStatistics();
             UpdateProjectorStats();
 
-            if (Sync.IsServer && stats.BuiltOnlyArmorBlocks)
-                requestRemap = true;
+            if (Sync.IsServer)
+            {
+                if (stats.BuiltOnlyArmorBlocks)
+                {
+                    // Requesting a remap once after the built blocks are cut down from the projector
+                    if (!remapRequested)
+                    {
+                        requestRemap = true;
+                        remapRequested = true;
+                    }
+                }
+                else
+                {
+                    // Allow for requesting a remap once after the built blocks are cut down from the projector
+                    remapRequested = false;
+                }
+            }
 
             UpdatePreviewBlockVisuals();
 

--- a/MultigridProjector/Logic/MultigridProjection.cs
+++ b/MultigridProjector/Logic/MultigridProjection.cs
@@ -559,6 +559,7 @@ namespace MultigridProjector.Logic
                 if (stats.BuiltOnlyArmorBlocks)
                 {
                     // Requesting a remap once after the built blocks are cut down from the projector
+                    // The actual remapping will happen right before the first fat block is built
                     if (!remapRequested)
                     {
                         requestRemap = true;

--- a/MultigridProjector/Logic/MultigridProjection.cs
+++ b/MultigridProjector/Logic/MultigridProjection.cs
@@ -128,6 +128,9 @@ namespace MultigridProjector.Logic
         // Controls when the plugin and Mod API can access projector information already
         internal bool IsValidForApi => Initialized && HasScanned;
 
+        // Enables updating audio and visuals
+        private readonly bool enableAudioVisualUpdates;
+
         public static void EnsureNoProjections()
         {
             int projectionCount;
@@ -159,6 +162,8 @@ namespace MultigridProjector.Logic
             Projector = projector;
             GridBuilders = gridBuilders;
             clipboard = projector.GetClipboard();
+
+            enableAudioVisualUpdates = !Sync.IsDedicated;
 
             latestKeepProjection = Projector.GetKeepProjection();
             latestShowOnlyBuildable = Projector.GetShowOnlyBuildable();
@@ -455,7 +460,7 @@ namespace MultigridProjector.Logic
 
         private void HidePreviewGrids()
         {
-            if (Sync.IsDedicated)
+            if (!enableAudioVisualUpdates)
                 return;
 
             foreach (var subgrid in subgrids)
@@ -547,9 +552,10 @@ namespace MultigridProjector.Logic
             if (Sync.IsServer && stats.BuiltOnlyArmorBlocks)
                 requestRemap = true;
 
-            if (!Sync.IsDedicated)
+            UpdatePreviewBlockVisuals();
+
+            if (enableAudioVisualUpdates)
             {
-                UpdatePreviewBlockVisuals();
                 Projector.UpdateSounds();
                 Projector.SetEmissiveStateWorking();
             }
@@ -652,7 +658,7 @@ namespace MultigridProjector.Logic
 
         private void UpdatePreviewBlockVisuals()
         {
-            if (Sync.IsDedicated)
+            if (!enableAudioVisualUpdates)
                 return;
 
             foreach (var subgrid in SupportedSubgrids)

--- a/MultigridProjector/Logic/MultigridProjection.cs
+++ b/MultigridProjector/Logic/MultigridProjection.cs
@@ -1665,8 +1665,11 @@ System.NullReferenceException: Object reference not set to an instance of an obj
             clipboard.ResetGridOrientation();
 
             var gridBuilders = clipboard.CopiedGrids;
+
+#if INCOMPLETE_UNTESTED
             if (!EnsureBuildableUnderLimits(gridBuilders))
                 return;
+#endif
 
             Projector.SetIsActivating(true);
             clipboard.Activate(() =>
@@ -1685,6 +1688,7 @@ System.NullReferenceException: Object reference not set to an instance of an obj
             });
         }
 
+#if INCOMPLETE_UNTESTED
         private bool EnsureBuildableUnderLimits(List<MyObjectBuilder_CubeGrid> gridBuilders)
         {
             var identity = MySession.Static.Players.TryGetIdentity(Projector.BuiltBy);
@@ -1733,6 +1737,7 @@ System.NullReferenceException: Object reference not set to an instance of an obj
             MyGuiAudio.PlaySound(MyGuiSounds.HudUnable);
             MyHud.Notifications.Add(MySession.GetNotificationForLimitResult(limitResult));
         }
+#endif
 
         private void UpdateSubgridConnectedness()
         {

--- a/MultigridProjector/Logic/MultigridProjection.cs
+++ b/MultigridProjector/Logic/MultigridProjection.cs
@@ -563,14 +563,12 @@ namespace MultigridProjector.Logic
                     {
                         requestRemap = true;
                         remapRequested = true;
-                        PluginLog.Debug($"Remap requested on projector {Projector.CustomName} [{Projector.EntityId}]");
                     }
                 }
                 else
                 {
                     // Allow for requesting a remap once after the built blocks are cut down from the projector
                     remapRequested = false;
-                    PluginLog.Debug($"Remap request allowed on projector {Projector.CustomName} [{Projector.EntityId}]");
                 }
             }
 

--- a/MultigridProjector/Logic/MultigridProjection.cs
+++ b/MultigridProjector/Logic/MultigridProjection.cs
@@ -55,9 +55,11 @@ namespace MultigridProjector.Logic
         private static readonly ThreadLocal<bool> IsBuildingProjectedBlock = new ThreadLocal<bool>();
         public static bool IsBuildingProjection() => IsBuildingProjectedBlock.Value;
 
+        // Enables updating audio and visuals
+        // Defaults to true for the Client and Dedicated Server, configured by UI on Torch
         // FIXME: Hacked the Torch plugin's config value here,
         // it should be replaced with proper plugin config for all targets
-        public static bool ConfiguredSetPreviewBlockVisuals;
+        public static bool SetPreviewBlockVisuals = true;
 
         public bool TryGetSupportedSubgrid(int gridIndex, out Subgrid subgrid)
         {
@@ -133,9 +135,6 @@ namespace MultigridProjector.Logic
         // Controls when the plugin and Mod API can access projector information already
         internal bool IsValidForApi => Initialized && HasScanned;
 
-        // Enables updating audio and visuals
-        private readonly bool setPreviewBlockVisuals;
-
         public static void EnsureNoProjections()
         {
             int projectionCount;
@@ -167,8 +166,6 @@ namespace MultigridProjector.Logic
             Projector = projector;
             GridBuilders = gridBuilders;
             clipboard = projector.GetClipboard();
-
-            setPreviewBlockVisuals = !Sync.IsDedicated || ConfiguredSetPreviewBlockVisuals;
 
             latestKeepProjection = Projector.GetKeepProjection();
             latestShowOnlyBuildable = Projector.GetShowOnlyBuildable();
@@ -465,7 +462,7 @@ namespace MultigridProjector.Logic
 
         private void HidePreviewGrids()
         {
-            if (!setPreviewBlockVisuals)
+            if (!SetPreviewBlockVisuals)
                 return;
 
             foreach (var subgrid in subgrids)
@@ -575,7 +572,7 @@ namespace MultigridProjector.Logic
 
             UpdatePreviewBlockVisuals();
 
-            if (setPreviewBlockVisuals)
+            if (SetPreviewBlockVisuals)
             {
                 Projector.UpdateSounds();
                 Projector.SetEmissiveStateWorking();
@@ -679,7 +676,7 @@ namespace MultigridProjector.Logic
 
         private void UpdatePreviewBlockVisuals(bool force=false)
         {
-            if (!setPreviewBlockVisuals)
+            if (!SetPreviewBlockVisuals)
                 return;
 
             foreach (var subgrid in SupportedSubgrids)

--- a/MultigridProjector/Logic/MultigridProjectorApiProvider.cs
+++ b/MultigridProjector/Logic/MultigridProjectorApiProvider.cs
@@ -18,7 +18,7 @@ namespace MultigridProjector.Logic
         private static MultigridProjectorApiProvider api;
         public static IMultigridProjectorApi Api => api ?? (api = new MultigridProjectorApiProvider());
 
-        public string Version => "0.6.1";
+        public string Version => "0.6.2";
 
         public int GetSubgridCount(long projectorId)
         {

--- a/MultigridProjector/Logic/Subgrid.cs
+++ b/MultigridProjector/Logic/Subgrid.cs
@@ -265,7 +265,7 @@ namespace MultigridProjector.Logic
             previewBlock.Orientation.GetQuaternion(out var previewBlockOrientation);
             orientationQuaternion *= previewBlockOrientation;
         }
-        
+
         #endregion
 
         #region Built Grid Registration
@@ -543,19 +543,20 @@ namespace MultigridProjector.Logic
 
         public void UpdatePreviewBlockVisuals(MyProjectorBase projector, bool showOnlyBuildable)
         {
-            if (Sync.IsDedicated)
-                return;
-
             if (PreviewGrid == null)
                 return;
 
             if (!Supported)
             {
-                HideUnsupportedPreviewGrid(projector);
+                if (!hidden)
+                {
+                    HidePreviewGrid(projector);
 
-                using (BlocksLock.Write())
-                    Blocks.Clear();
+                    using (BlocksLock.Write())
+                        Blocks.Clear();
 
+                    hidden = true;
+                }
                 return;
             }
 
@@ -566,23 +567,8 @@ namespace MultigridProjector.Logic
             }
         }
 
-        private void HideUnsupportedPreviewGrid(MyProjectorBase projector)
-        {
-            if (hidden)
-                return;
-
-            HidePreviewGrid(projector);
-            hidden = true;
-        }
-
         public void HidePreviewGrid(MyProjectorBase projector)
         {
-            if (Sync.IsDedicated)
-                return;
-
-            if (PreviewGrid == null)
-                return;
-
             foreach (var slimBlock in PreviewGrid.CubeBlocks)
                 projector.HideCube(slimBlock);
         }
@@ -651,7 +637,7 @@ namespace MultigridProjector.Logic
 
             stats.Clear();
 
-            var stateHash = unchecked (0xdeadbeafdeadbeaful * (ulong) (1 + Index));
+            var stateHash = unchecked(0xdeadbeafdeadbeaful * (ulong) (1 + Index));
 
             MyCubeGrid builtGrid;
             using (BuiltGridLock.Read())

--- a/MultigridProjector/Logic/Subgrid.cs
+++ b/MultigridProjector/Logic/Subgrid.cs
@@ -65,6 +65,9 @@ namespace MultigridProjector.Logic
         // Block state hash
         public ulong StateHash { get; private set; }
 
+        // Block state hash of the last visual update
+        private ulong latestVisualUpdateStateHash;
+
         // Indicates whether an unsupported preview grid has already been hidden
         private bool hidden;
 
@@ -562,6 +565,11 @@ namespace MultigridProjector.Logic
 
             using (BlocksLock.Read())
             {
+                if (latestVisualUpdateStateHash == StateHash)
+                    return;
+
+                latestVisualUpdateStateHash = StateHash;
+
                 foreach (var projectedBlock in Blocks.Values)
                     projectedBlock.UpdateVisual(projector, showOnlyBuildable);
             }

--- a/MultigridProjector/Logic/Subgrid.cs
+++ b/MultigridProjector/Logic/Subgrid.cs
@@ -544,7 +544,7 @@ namespace MultigridProjector.Logic
 
         #region Preview Block Visuals
 
-        public void UpdatePreviewBlockVisuals(MyProjectorBase projector, bool showOnlyBuildable)
+        public void UpdatePreviewBlockVisuals(MyProjectorBase projector, bool showOnlyBuildable, bool force)
         {
             if (PreviewGrid == null)
                 return;
@@ -565,7 +565,7 @@ namespace MultigridProjector.Logic
 
             using (BlocksLock.Read())
             {
-                if (latestVisualUpdateStateHash == StateHash)
+                if (!force && latestVisualUpdateStateHash == StateHash)
                     return;
 
                 latestVisualUpdateStateHash = StateHash;

--- a/MultigridProjector/Utilities/MultigridProjectorConfig.cs
+++ b/MultigridProjector/Utilities/MultigridProjectorConfig.cs
@@ -1,9 +1,11 @@
 namespace MultigridProjector.Utilities
 {
+#if UNUSED
     // FIXME: This is only a stub, will need a better implementation
     public static class MultigridProjectorConfig
     {
         public static bool BlockLimit { get; set; }
         public static bool PcuLimit { get; set; }
     }
+#endif
 }

--- a/MultigridProjectorApi/Api/IMultigridProjectorApi.cs
+++ b/MultigridProjectorApi/Api/IMultigridProjectorApi.cs
@@ -7,7 +7,7 @@ namespace MultigridProjector.Api
 {
     public interface IMultigridProjectorApi
     {
-        // Multigrid Projector version: 0.6.1
+        // Multigrid Projector version: 0.6.2
         string Version { get; }
 
         // Returns the number of subgrids in the active projection, returns zero if there is no projection

--- a/MultigridProjectorClient/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorClient/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.1.0")]
-[assembly: AssemblyFileVersion("0.6.1.0")]
+[assembly: AssemblyVersion("0.6.2.0")]
+[assembly: AssemblyFileVersion("0.6.2.0")]

--- a/MultigridProjectorDedicated/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorDedicated/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.1.0")]
-[assembly: AssemblyFileVersion("0.6.1.0")]
+[assembly: AssemblyVersion("0.6.2.0")]
+[assembly: AssemblyFileVersion("0.6.2.0")]

--- a/MultigridProjectorDedicated/manifest.xml
+++ b/MultigridProjectorDedicated/manifest.xml
@@ -3,5 +3,5 @@
   <Name>Multigrid Projector</Name>
   <Guid>d4f47dcb-9c07-4c1a-bc8c-ce42e87683ee</Guid>
   <Repository>MultigridProjectorDedicated</Repository>
-  <Version>v0.6.1.0</Version>
+  <Version>v0.6.2.0</Version>
 </PluginManifest>

--- a/MultigridProjectorServer/ConfigView.xaml
+++ b/MultigridProjectorServer/ConfigView.xaml
@@ -1,0 +1,39 @@
+<!-- ReSharper disable once Xaml.RedundantNamespaceAlias -->
+<UserControl x:Class="MultigridProjectorServer.ConfigView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:MultigridProjectorServer"
+             mc:Ignorable="d"
+             d:DesignHeight="450" d:DesignWidth="800">
+
+    <Grid>
+
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" SharedSizeGroup="Labels" />
+            <ColumnDefinition Width="Auto" SharedSizeGroup="Checkboxes" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" SharedSizeGroup="Buttons" />
+        </Grid.ColumnDefinitions>
+
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <!-- TODO: Add row definitions if you start using new rows -->
+        </Grid.RowDefinitions>
+
+        <!-- Title -->
+        <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="4" Text="Multigrid Projector" FontWeight="Bold" FontSize="16" VerticalAlignment="Center" Margin="5" />
+
+        <!-- Compatibility -->
+        <Separator Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="4"></Separator>
+        <TextBlock Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="4" Text="Compatibility" FontWeight="Bold" FontSize="14" VerticalAlignment="Center" Margin="5" />
+
+        <!-- Set preview block visuals -->
+        <CheckBox Grid.Row="3" Grid.Column="0" Name="SetPreviewBlockVisuals" IsChecked="{Binding SetPreviewBlockVisuals}" Margin="5" />
+        <TextBlock Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="3" Text="Set preview block visuals on server side (required by mods depending on preview block transparency)" VerticalAlignment="Center" Margin="5" />
+    </Grid>
+</UserControl>

--- a/MultigridProjectorServer/ConfigView.xaml.cs
+++ b/MultigridProjectorServer/ConfigView.xaml.cs
@@ -1,0 +1,15 @@
+using System.Windows.Controls;
+
+namespace MultigridProjectorServer
+{
+    // ReSharper disable once UnusedType.Global
+    // ReSharper disable once RedundantExtendsListEntry
+    public partial class ConfigView : UserControl
+    {
+        public ConfigView()
+        {
+            InitializeComponent();
+            DataContext = MultigridProjectorConfig.Instance;
+        }
+    }
+}

--- a/MultigridProjectorServer/ConfigView.xaml.cs
+++ b/MultigridProjectorServer/ConfigView.xaml.cs
@@ -9,7 +9,7 @@ namespace MultigridProjectorServer
         public ConfigView()
         {
             InitializeComponent();
-            DataContext = MultigridProjectorConfig.Instance;
+            DataContext = MultigridProjectorPlugin.Instance.Config;
         }
     }
 }

--- a/MultigridProjectorServer/MultigridProjectorCommands.cs
+++ b/MultigridProjectorServer/MultigridProjectorCommands.cs
@@ -4,56 +4,58 @@ using VRage.Game.ModAPI;
 
 namespace MultigridProjectorServer
 {
-    // [Category("multigrid")]
-    // public class MultigridProjectorCommands : CommandModule
-    // {
-    //     [Command("info", "Prints the current settings")]
-    //     [Permission(MyPromoteLevel.None)]
-    //     public void Info()
-    //     {
-    //         if (!MultigridProjectorConfig.Instance.EnablePlugin)
-    //         {
-    //             Context.Respond("Multigrid Projector plugin is disabled");
-    //             return;
-    //         }
-    //
-    //         var identityId = Context.Player.IdentityId;
-    //         if (identityId == 0L)
-    //         {
-    //             Context.Respond("This command can only be used in game");
-    //             return;
-    //         }
-    //
-    //         RespondWithInfo();
-    //     }
-    //
-    //     [Command("block limit", "Enables or disables enforcing player block limits")]
-    //     [Permission(MyPromoteLevel.Admin)]
-    //     public void BlockLimit(bool enable)
-    //     {
-    //         MultigridProjectorConfig.Instance.BlockLimit = enable;
-    //         RespondWithInfo();
-    //     }
-    //
-    //     [Command("block limit", "Enables or disables enforcing player block limits")]
-    //     [Permission(MyPromoteLevel.Admin)]
-    //     public void PcuLimit(bool enable)
-    //     {
-    //         MultigridProjectorConfig.Instance.PcuLimit = enable;
-    //         RespondWithInfo();
-    //     }
-    //
-    //     private void RespondWithInfo()
-    //     {
-    //         var config = MultigridProjectorConfig.Instance;
-    //         Context.Respond("Multigrid Projector:\r\n" +
-    //                         $"Block limit: {FormatBool(config.BlockLimit)}\r\n" +
-    //                         $"PCU limit: {FormatBool(config.PcuLimit)}");
-    //     }
-    //
-    //     private static string FormatBool(bool value)
-    //     {
-    //         return value ? "Yes" : "No";
-    //     }
-    // }
+#if INCOMPLETE_UNTESTED
+    [Category("multigrid")]
+    public class MultigridProjectorCommands : CommandModule
+    {
+        [Command("info", "Prints the current settings")]
+        [Permission(MyPromoteLevel.None)]
+        public void Info()
+        {
+            if (!MultigridProjectorConfig.Instance.EnablePlugin)
+            {
+                Context.Respond("Multigrid Projector plugin is disabled");
+                return;
+            }
+
+            var identityId = Context.Player.IdentityId;
+            if (identityId == 0L)
+            {
+                Context.Respond("This command can only be used in game");
+                return;
+            }
+
+            RespondWithInfo();
+        }
+
+        [Command("block limit", "Enables or disables enforcing player block limits")]
+        [Permission(MyPromoteLevel.Admin)]
+        public void BlockLimit(bool enable)
+        {
+            MultigridProjectorConfig.Instance.BlockLimit = enable;
+            RespondWithInfo();
+        }
+
+        [Command("block limit", "Enables or disables enforcing player block limits")]
+        [Permission(MyPromoteLevel.Admin)]
+        public void PcuLimit(bool enable)
+        {
+            MultigridProjectorConfig.Instance.PcuLimit = enable;
+            RespondWithInfo();
+        }
+
+        private void RespondWithInfo()
+        {
+            var config = MultigridProjectorConfig.Instance;
+            Context.Respond("Multigrid Projector:\r\n" +
+                            $"Block limit: {FormatBool(config.BlockLimit)}\r\n" +
+                            $"PCU limit: {FormatBool(config.PcuLimit)}");
+        }
+
+        private static string FormatBool(bool value)
+        {
+            return value ? "Yes" : "No";
+        }
+    }
+#endif
 }

--- a/MultigridProjectorServer/MultigridProjectorConfig.cs
+++ b/MultigridProjectorServer/MultigridProjectorConfig.cs
@@ -15,26 +15,30 @@ namespace MultigridProjectorServer
         private static readonly string ConfigFileName = "MultigridProjector.cfg";
         private static bool _loading;
 
-        private bool _enablePlugin = true;
+        private bool _setPreviewBlockVisuals = true;
+
+#if INCOMPLETE_UNTESTED
         private bool _blockLimit;
         private bool _pcuLimit;
+#endif
 
         private static MultigridProjectorConfig _instance;
         public static MultigridProjectorConfig Instance => _instance ?? (_instance = new MultigridProjectorConfig());
         private static XmlSerializer ConfigSerializer => new XmlSerializer(typeof(MultigridProjectorConfig));
         private static string ConfigFilePath => Path.Combine(MultigridProjectorPlugin.Instance.StoragePath, ConfigFileName);
 
-        [Display(Description = "Enables/disables the plugin", Name = "Enable Plugin", Order = 1)]
-        public bool EnablePlugin
+        [Display(Order = 1, GroupName = "Compatibility", Name = "Set preview block visuals", Description = "Compatibility with mods depending on preview block transparency.")]
+        public bool SetPreviewBlockVisuals
         {
-            get => _enablePlugin;
+            get => _setPreviewBlockVisuals;
             set
             {
-                _enablePlugin = value;
-                OnPropertyChanged(nameof(EnablePlugin));
+                _setPreviewBlockVisuals = value;
+                OnPropertyChanged(nameof(SetPreviewBlockVisuals));
             }
         }
 
+#if INCOMPLETE_UNTESTED
         [Display(Description = "Enforce player block limit", Name = "Block limit", Order = 2)]
         public bool BlockLimit
         {
@@ -56,6 +60,7 @@ namespace MultigridProjectorServer
                 OnPropertyChanged(nameof(PcuLimit));
             }
         }
+#endif
 
         protected override void OnPropertyChanged(string propName = "")
         {

--- a/MultigridProjectorServer/MultigridProjectorPlugin.cs
+++ b/MultigridProjectorServer/MultigridProjectorPlugin.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Reflection;
 using System.Windows.Controls;
 using HarmonyLib;
@@ -32,6 +33,9 @@ namespace MultigridProjectorServer
         public UserControl GetControl() => control ?? (control = new ConfigView());
         private ConfigView control;
 
+        private Persistent<MultigridProjectorConfig> config;
+        public MultigridProjectorConfig Config => config?.Data;
+
         private MultigridProjectorSession mgpSession;
 
         private static Harmony Harmony => new Harmony("com.spaceengineers.multigridprojector");
@@ -44,6 +48,9 @@ namespace MultigridProjectorServer
 
             PluginLog.Logger = new PluginLogger(PluginLog.Prefix);
             PluginLog.Prefix = "";
+
+            var configPath = Path.Combine(StoragePath, MultigridProjectorConfig.ConfigFilePath);
+            config = Persistent<MultigridProjectorConfig>.Load(configPath);
 
             try
             {
@@ -75,6 +82,10 @@ namespace MultigridProjectorServer
                 case TorchSessionState.Loading:
                     break;
                 case TorchSessionState.Loaded:
+
+                    // FIXME: Hacking the config there, replace with proper plugin config
+                    MultigridProjection.ConfiguredSetPreviewBlockVisuals = Config.SetPreviewBlockVisuals;
+
                     mgpSession = new MultigridProjectorSession();
                     break;
 

--- a/MultigridProjectorServer/MultigridProjectorPlugin.cs
+++ b/MultigridProjectorServer/MultigridProjectorPlugin.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reflection;
+using System.Windows.Controls;
 using HarmonyLib;
 using MultigridProjector.Api;
 using MultigridProjector.Logic;
@@ -7,13 +8,14 @@ using MultigridProjector.Utilities;
 using Torch;
 using Torch.API;
 using Torch.API.Managers;
+using Torch.API.Plugins;
 using Torch.API.Session;
 using Torch.Session;
 
 namespace MultigridProjectorServer
 {
     // ReSharper disable once ClassNeverInstantiated.Global
-    public class MultigridProjectorPlugin : TorchPluginBase
+    public class MultigridProjectorPlugin : TorchPluginBase, IWpfPlugin
     {
         public static MultigridProjectorPlugin Instance { get; private set; }
         private TorchSessionManager _sessionManager;
@@ -25,6 +27,10 @@ namespace MultigridProjectorServer
 
         // ReSharper disable once UnusedMember.Local
         // private readonly MultigridProjectorCommands _commands = new MultigridProjectorCommands();
+
+        // ReSharper disable once UnusedMember.Global
+        public UserControl GetControl() => control ?? (control = new ConfigView());
+        private ConfigView control;
 
         private MultigridProjectorSession mgpSession;
 
@@ -71,6 +77,7 @@ namespace MultigridProjectorServer
                 case TorchSessionState.Loaded:
                     mgpSession = new MultigridProjectorSession();
                     break;
+
                 case TorchSessionState.Unloading:
                     if (mgpSession != null)
                     {

--- a/MultigridProjectorServer/MultigridProjectorPlugin.cs
+++ b/MultigridProjectorServer/MultigridProjectorPlugin.cs
@@ -80,7 +80,7 @@ namespace MultigridProjectorServer
         private void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             // FIXME: Hacking the config there, replace with proper plugin config
-            MultigridProjection.ConfiguredSetPreviewBlockVisuals = Config.SetPreviewBlockVisuals;
+            MultigridProjection.SetPreviewBlockVisuals = Config.SetPreviewBlockVisuals;
         }
 
         private void SessionStateChanged(ITorchSession session, TorchSessionState newstate)
@@ -92,7 +92,7 @@ namespace MultigridProjectorServer
                 case TorchSessionState.Loaded:
 
                     // FIXME: Hacking the config there, replace with proper plugin config
-                    MultigridProjection.ConfiguredSetPreviewBlockVisuals = Config.SetPreviewBlockVisuals;
+                    MultigridProjection.SetPreviewBlockVisuals = Config.SetPreviewBlockVisuals;
 
                     mgpSession = new MultigridProjectorSession();
                     break;

--- a/MultigridProjectorServer/MultigridProjectorPlugin.cs
+++ b/MultigridProjectorServer/MultigridProjectorPlugin.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.IO;
 using System.Reflection;
 using System.Windows.Controls;
@@ -51,6 +52,7 @@ namespace MultigridProjectorServer
 
             var configPath = Path.Combine(StoragePath, MultigridProjectorConfig.ConfigFilePath);
             config = Persistent<MultigridProjectorConfig>.Load(configPath);
+            config.Data.PropertyChanged += OnPropertyChanged;
 
             try
             {
@@ -73,6 +75,12 @@ namespace MultigridProjectorServer
             _sessionManager.SessionStateChanged += SessionStateChanged;
 
             PluginLog.Info("Loaded server plugin");
+        }
+
+        private void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            // FIXME: Hacking the config there, replace with proper plugin config
+            MultigridProjection.ConfiguredSetPreviewBlockVisuals = Config.SetPreviewBlockVisuals;
         }
 
         private void SessionStateChanged(ITorchSession session, TorchSessionState newstate)

--- a/MultigridProjectorServer/MultigridProjectorServer.csproj
+++ b/MultigridProjectorServer/MultigridProjectorServer.csproj
@@ -39,6 +39,8 @@
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c">
       <HintPath>$(Torch)\DedicatedServer64\NLog.dll</HintPath>
     </Reference>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
     <Reference Include="Sandbox.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>$(Torch)\DedicatedServer64\Sandbox.Common.dll</HintPath>
     </Reference>
@@ -63,6 +65,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />
     <Reference Include="Torch, Culture=neutral, PublicKeyToken=null">
       <HintPath>$(Torch)\Torch.dll</HintPath>
@@ -94,9 +97,11 @@
     <Reference Include="VRage.Scripting, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>$(Torch)\DedicatedServer64\VRage.Scripting.dll</HintPath>
     </Reference>
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Api\MultigridProjectorTorchAgent.cs" />
+    <Compile Include="ConfigView.xaml.cs" />
     <Compile Include="EnsureOriginalTorch.cs" />
     <Compile Include="MultigridProjectorCommands.cs" />
     <Compile Include="MultigridProjectorConfig.cs" />
@@ -129,6 +134,9 @@
   <ItemGroup>
     <PackageReference Include="Lib.Harmony" Version="2.2.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <Page Include="ConfigView.xaml" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\MultigridProjector\MultigridProjector.projitems" Label="Shared" />

--- a/MultigridProjectorServer/Properties/AssemblyInfo.cs
+++ b/MultigridProjectorServer/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.1.0")]
-[assembly: AssemblyFileVersion("0.6.1.0")]
+[assembly: AssemblyVersion("0.6.2.0")]
+[assembly: AssemblyFileVersion("0.6.2.0")]

--- a/MultigridProjectorServer/manifest.xml
+++ b/MultigridProjectorServer/manifest.xml
@@ -3,5 +3,5 @@
   <Name>Multigrid Projector</Name>
   <Guid>d9359ba0-9a69-41c3-971d-eb5170adb97e</Guid>
   <Repository>MultigridProjectorServer</Repository>
-  <Version>v0.6.1.0</Version>
+  <Version>v0.6.2.0</Version>
 </PluginManifest>


### PR DESCRIPTION
- Implemented Torch config UI (no proper target independent configuration yet, it is currently Torch only and separate from the client config options)
- Torch configuration option: Set preview block visuals on server side (required by mods depending on preview block transparency) [DEFAULT: OFF]
- Enabled "set preview block visuals" permanently on Dedicated Server to avoid the same issue by default (configuration may be added later)
- Minor optimization to setting the preview block visuals on client side (not setting them redundantly if the whole subgrid is unchanged)

Set the new Torch configuration option if you use the ToolCore mod. It is required for ToolCore welders to work until a proper fix is implemented in the mod. Enabling this option has a minor server performance impact during welding, therefore it should be disabled once the mod is fixed.