### PR TITLE
Fix PL build error

### DIFF
--- a/MultigridProjector/Extensions/MyObjectBuilderExtensions.cs
+++ b/MultigridProjector/Extensions/MyObjectBuilderExtensions.cs
@@ -83,12 +83,18 @@ namespace MultigridProjector.Extensions
             if (terminalBlockBuilder.CustomName != null)
                 return terminalBlockBuilder.CustomName;
 
-            MyCubeBlockDefinition blockDefinition;
-            var defaultName =
-                MyDefinitionManager.Static?.TryGetDefinition(terminalBlockBuilder.SubtypeId,
-                    out blockDefinition) == true
-                    ? blockDefinition.DisplayNameText
-                    : terminalBlockBuilder.SubtypeId.ToString();
+            string defaultName;
+            MyCubeBlockDefinition blockDefinition = null;
+
+            if (MyDefinitionManager.Static?.TryGetDefinition(terminalBlockBuilder.SubtypeId, out blockDefinition) ?? false)
+            {
+                defaultName = blockDefinition.DisplayNameText;
+            }
+            else
+            {
+                defaultName = terminalBlockBuilder.SubtypeId.ToString();
+            }
+
             return terminalBlockBuilder.NumberInGrid > 1
                 ? $"{defaultName} {terminalBlockBuilder.NumberInGrid}"
                 : defaultName;

--- a/MultigridProjector/Extensions/MyObjectBuilderExtensions.cs
+++ b/MultigridProjector/Extensions/MyObjectBuilderExtensions.cs
@@ -83,8 +83,15 @@ namespace MultigridProjector.Extensions
             if (terminalBlockBuilder.CustomName != null)
                 return terminalBlockBuilder.CustomName;
 
-            var defaultName = MyDefinitionManager.Static?.TryGetDefinition<MyCubeBlockDefinition>(terminalBlockBuilder.SubtypeId, out var blockDefinition) == true ? blockDefinition.DisplayNameText : terminalBlockBuilder.SubtypeId.ToString();
-            return terminalBlockBuilder.NumberInGrid > 1 ? $"{defaultName} {terminalBlockBuilder.NumberInGrid}" : defaultName;
+            MyCubeBlockDefinition blockDefinition;
+            var defaultName =
+                MyDefinitionManager.Static?.TryGetDefinition(terminalBlockBuilder.SubtypeId,
+                    out blockDefinition) == true
+                    ? blockDefinition.DisplayNameText
+                    : terminalBlockBuilder.SubtypeId.ToString();
+            return terminalBlockBuilder.NumberInGrid > 1
+                ? $"{defaultName} {terminalBlockBuilder.NumberInGrid}"
+                : defaultName;
         }
 
         public static bool AlignToRepairProjector(this MyObjectBuilder_CubeGrid gridBuilder, MyProjectorBase projector)


### PR DESCRIPTION
Upon 0.7.0 release I got this error report from a user:

```
2024-05-03 22:10:35.411 - Thread:   1 ->  [PluginLoader] [Info] Downloading https://github.com/viktor-ferenczi/multigrid-projector/archive/ff9143a627450e6162f4bf9dd4a74794ec3ec085.zip
2024-05-03 22:10:39.364 - Thread:   1 ->  [PluginLoader] [Error] CS0165: Use of unassigned local variable 'blockDefinition' in file:
multigrid-projector-ff9143a627450e6162f4bf9dd4a74794ec3ec085/MultigridProjector/Extensions/MyObjectBuilderExtensions.cs (86,166)
2024-05-03 22:10:39.373 - Thread:   1 ->  [PluginLoader] [Error] Failed to load viktor-ferenczi/multigrid-projector|Multigrid Projector because of an error: System.Exception: Compilation failed!
   at avaness.PluginLoader.Compiler.RoslynCompiler.Compile(String assemblyName, Byte[]& symbols)
   at avaness.PluginLoader.Data.GitHubPlugin.CompileFromSource(String commit, String assemblyName, Action`1 callback)
   at avaness.PluginLoader.Data.GitHubPlugin.GetAssembly()
   at avaness.PluginLoader.Data.PluginData.TryLoadAssembly(Assembly& a)
```

This is an attempt to fix this.