### PR TITLE
Updating block references and client side build fixes

### DIFF
--- a/MultigridProjector/Extensions/MyCubeBlockExtensions.cs
+++ b/MultigridProjector/Extensions/MyCubeBlockExtensions.cs
@@ -126,20 +126,6 @@ namespace MultigridProjector.Extensions
             return (Sync<long, SyncDirection.BothWays>)BoundCameraSyncField.GetValue(remoteControlBlock);
         }
 
-        private static readonly MethodInfo AddBlocksMethod = AccessTools.DeclaredMethod(typeof(MyEventControllerBlock), "AddBlocks");
-
-        public static void AddBlocks(this MyEventControllerBlock eventControllerBlock, List<long> toSync)
-        {
-            AddBlocksMethod.Invoke(eventControllerBlock, new[] { toSync });
-        }
-
-        private static readonly MethodInfo RemoveBlocksMethod = AccessTools.DeclaredMethod(typeof(MyEventControllerBlock), "RemoveBlocks");
-
-        public static void RemoveBlocks(this MyEventControllerBlock eventControllerBlock, List<long> toSync)
-        {
-            RemoveBlocksMethod.Invoke(eventControllerBlock, new[] { toSync });
-        }
-
         private static readonly FieldInfo SelectedBlockIdsField = AccessTools.DeclaredField(typeof(MyEventControllerBlock), "m_selectedBlockIds");
 
         public static MySerializableList<long> GetSelectedBlockIds(this MyEventControllerBlock eventControllerBlock)
@@ -159,28 +145,22 @@ namespace MultigridProjector.Extensions
             return (Dictionary<long, IMyTerminalBlock>)SelectedBlocksField.GetValue(eventControllerBlock);
         }
 
-        private static readonly FieldInfo SelectedBlockIdsFieldInfo = AccessTools.Field(typeof(MyEventControllerBlock), "m_selectedBlockIds");
-        
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static MySerializableList<long> GetSelectedBlockIds(this MyEventControllerBlock block)
-        {
-            return SelectedBlockIdsFieldInfo.GetValue(block) as MySerializableList<long>;
-        }
+        private static readonly MethodInfo SelectAvailableBlocksMethod = AccessTools.DeclaredMethod(typeof(MyEventControllerBlock), "SelectAvailableBlocks");
 
-        private static readonly MethodInfo SelectAvailableBlocksMethodInfo = AccessTools.DeclaredMethod(typeof(MyEventControllerBlock), "SelectAvailableBlocks");
-        
+        // ReSharper disable once UnusedMember.Global
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void SelectAvailableBlocks(this MyEventControllerBlock block, List<MyGuiControlListbox.Item> selection)
         {
-            SelectAvailableBlocksMethodInfo.Invoke(block, new object[]{selection});
+            SelectAvailableBlocksMethod.Invoke(block, new object[] { selection });
         }
 
-        private static readonly MethodInfo SelectButtonMethodInfo = AccessTools.DeclaredMethod(typeof(MyEventControllerBlock), "SelectButton");
-        
+        private static readonly MethodInfo SelectButtonMethod = AccessTools.DeclaredMethod(typeof(MyEventControllerBlock), "SelectButton");
+
+        // ReSharper disable once UnusedMember.Global
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void SelectButton(this MyEventControllerBlock block)
         {
-            SelectButtonMethodInfo.Invoke(block, new object[]{});
+            SelectButtonMethod.Invoke(block, new object[] { });
         }
     }
 }

--- a/MultigridProjector/Extensions/MyCubeBlockExtensions.cs
+++ b/MultigridProjector/Extensions/MyCubeBlockExtensions.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Sandbox.Game.Screens.Helpers;
 using Sandbox.ModAPI;
+using Sandbox.Graphics.GUI;
 using SpaceEngineers.Game.Entities.Blocks;
 using VRage.Game;
 using VRage.ObjectBuilder;
@@ -156,6 +157,30 @@ namespace MultigridProjector.Extensions
         public static Dictionary<long, IMyTerminalBlock> GetSelectedBlocks(this MyEventControllerBlock eventControllerBlock)
         {
             return (Dictionary<long, IMyTerminalBlock>)SelectedBlocksField.GetValue(eventControllerBlock);
+        }
+
+        private static readonly FieldInfo SelectedBlockIdsFieldInfo = AccessTools.Field(typeof(MyEventControllerBlock), "m_selectedBlockIds");
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static MySerializableList<long> GetSelectedBlockIds(this MyEventControllerBlock block)
+        {
+            return SelectedBlockIdsFieldInfo.GetValue(block) as MySerializableList<long>;
+        }
+
+        private static readonly MethodInfo SelectAvailableBlocksMethodInfo = AccessTools.DeclaredMethod(typeof(MyEventControllerBlock), "SelectAvailableBlocks");
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void SelectAvailableBlocks(this MyEventControllerBlock block, List<MyGuiControlListbox.Item> selection)
+        {
+            SelectAvailableBlocksMethodInfo.Invoke(block, new object[]{selection});
+        }
+
+        private static readonly MethodInfo SelectButtonMethodInfo = AccessTools.DeclaredMethod(typeof(MyEventControllerBlock), "SelectButton");
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void SelectButton(this MyEventControllerBlock block)
+        {
+            SelectButtonMethodInfo.Invoke(block, new object[]{});
         }
     }
 }

--- a/MultigridProjector/Logic/MultigridProjection.cs
+++ b/MultigridProjector/Logic/MultigridProjection.cs
@@ -270,7 +270,7 @@ namespace MultigridProjector.Logic
 
             if (!terminalBlockAddedQueue.Contains(projectedBlock))
                 terminalBlockAddedQueue.Add(projectedBlock);
-            
+
             subgrid.RequestUpdate();
         }
 
@@ -622,7 +622,7 @@ namespace MultigridProjector.Logic
 
             if (!latestKeepProjection && IsBuildCompleted)
                 Projector.RequestRemoveProjection();
-            
+
             ScheduleTerminalBlocksForRestore();
         }
 
@@ -635,15 +635,15 @@ namespace MultigridProjector.Logic
                 else
                     terminalBlockRetryQueue.Add(projectedBlock);
             }
-            
+
             terminalBlockAddedQueue.AddRange(terminalBlockRetryQueue);
             terminalBlockRetryQueue.Clear();
         }
-        
+
         private void RestoreTerminalBlocks()
         {
             // This is called periodically from the main thread
-            while(terminalBlockRestoreQueue.TryDequeueBack(out var projectedBlock))
+            while (terminalBlockRestoreQueue.TryDequeueBack(out var projectedBlock))
             {
                 referenceFixer.Restore(projectedBlock);
             }
@@ -2156,7 +2156,7 @@ System.NullReferenceException: Object reference not set to an instance of an obj
         [ServerOnly]
         public static bool ShouldAllowBuildingDefaultTopBlock(MyMechanicalConnectionBlockBase baseBlock)
         {
-            if (!TryFindProjectionByBuiltGrid(baseBlock.CubeGrid, out var projection, out var subgrid))
+            if (!TryFindProjectionByBuiltGrid(baseBlock.CubeGrid, out var _, out var subgrid))
             {
                 return true;
             }
@@ -2164,6 +2164,30 @@ System.NullReferenceException: Object reference not set to an instance of an obj
             var baseBlockPreviewPosition = subgrid.BuiltToPreviewBlockPosition(baseBlock.Position);
             var result = !subgrid.BaseConnections.ContainsKey(baseBlockPreviewPosition);
             return result;
+        }
+
+        public bool TryMapPreviewToBuiltTerminalBlockId(long previewBlockId, out long blockId)
+        {
+            if (!referenceFixer.TryMapPreviewToBuiltTerminalBlock<MyTerminalBlock>(previewBlockId, out var terminalBlock))
+            {
+                blockId = 0;
+                return false;
+            }
+
+            blockId = terminalBlock.EntityId;
+            return true;
+        }
+
+        public IEnumerable<long> MapPreviewToBuiltTerminalBlockIds(IEnumerable<long> previewBlockIds)
+        {
+            if (previewBlockIds == null)
+                yield break;
+
+            foreach (var bpBlockId in previewBlockIds)
+            {
+                if (referenceFixer.TryMapPreviewToBuiltTerminalBlock<MyTerminalBlock>(bpBlockId, out var terminalBlock))
+                    yield return terminalBlock.EntityId;
+            }
         }
     }
 }

--- a/MultigridProjector/Logic/MultigridProjection.cs
+++ b/MultigridProjector/Logic/MultigridProjection.cs
@@ -651,7 +651,13 @@ namespace MultigridProjector.Logic
             // This is called periodically from the main thread
             while (terminalBlockRestoreQueue.TryDequeueBack(out var projectedBlock))
             {
-                referenceFixer.Restore(projectedBlock);
+                if (Sync.IsServer)
+                    referenceFixer.RestoreSafe(projectedBlock);
+                else
+                {
+                    var capturedProjectedBlock = projectedBlock;
+                    Events.InvokeOnGameThread(() => referenceFixer.RestoreSafe(capturedProjectedBlock), 60);
+                }
             }
         }
 
@@ -2152,7 +2158,7 @@ System.NullReferenceException: Object reference not set to an instance of an obj
 
         public void FixBlockRelations()
         {
-            referenceFixer.RestoreAll();
+            referenceFixer.RestoreAllSafe();
         }
 
         [ServerOnly]

--- a/MultigridProjector/Logic/MultigridProjection.cs
+++ b/MultigridProjector/Logic/MultigridProjection.cs
@@ -69,6 +69,12 @@ namespace MultigridProjector.Logic
         // ReSharper disable once UnassignedField.Global
         public bool CheckHavokIntersections;
 
+        // Queue of newly built terminal blocks, some of their properties point to other blocks, which need to be
+        // restored according to the blueprint once both the referencing and referred blocks are built  
+        private readonly MyConcurrentList<ProjectedBlock> terminalBlockAddedQueue = new MyConcurrentList<ProjectedBlock>(32);
+        private readonly MyConcurrentList<ProjectedBlock> terminalBlockRestoreQueue = new MyConcurrentList<ProjectedBlock>(32);
+        private readonly List<ProjectedBlock> terminalBlockRetryQueue = new List<ProjectedBlock>(8);
+        
         public bool TryGetProjectedBlock(FastBlockLocation blockLocation, out Subgrid subgrid, out ProjectedBlock projectedBlock)
         {
             subgrid = null;
@@ -1517,17 +1523,13 @@ System.NullReferenceException: Object reference not set to an instance of an obj
         }
 
         private const int MaxHandWeldableCubes = 32;
+        private readonly ThreadLocal<FindProjectedBlockLocals> findProjectedBlockLocals = new ThreadLocal<FindProjectedBlockLocals>();
 
         private class FindProjectedBlockLocals
         {
             public readonly MyCube[] Cubes = new MyCube[MaxHandWeldableCubes];
             public readonly double[] Distances = new double[MaxHandWeldableCubes];
         }
-
-        private readonly ThreadLocal<FindProjectedBlockLocals> findProjectedBlockLocals = new ThreadLocal<FindProjectedBlockLocals>();
-        private readonly MyConcurrentList<ProjectedBlock> terminalBlockAddedQueue = new MyConcurrentList<ProjectedBlock>(32);
-        private readonly MyConcurrentList<ProjectedBlock> terminalBlockRestoreQueue = new MyConcurrentList<ProjectedBlock>(32);
-        private readonly List<ProjectedBlock> terminalBlockRetryQueue = new List<ProjectedBlock>(8);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void FindProjectedBlock(Vector3D center, Vector3D reachFarPoint, ref MyWelder.ProjectionRaycastData raycastData)

--- a/MultigridProjectorClient/Extra/ConnectSubgrids.cs
+++ b/MultigridProjectorClient/Extra/ConnectSubgrids.cs
@@ -259,7 +259,7 @@ namespace MultigridProjectorClient.Extra
 
                     UpdateBlock.CopyProperties(sourceBase, newBase);
                 }
-
+                
                 Events.OnBlockSpawned(
                     (block) => OnNewBaseBuild((MyMechanicalConnectionBlockBase)block.FatBlock),
                     (block) => block.BlockDefinition == sourceBase.BlockDefinition);

--- a/MultigridProjectorClient/Utilities/UpdateBlock.cs
+++ b/MultigridProjectorClient/Utilities/UpdateBlock.cs
@@ -98,7 +98,8 @@ namespace MultigridProjectorClient.Utilities
 
         private static readonly HashSet<string> ExcludedEventControllerPropertiesTurretController = new HashSet<string>
         {
-            // These are filled by ReferenceFixer
+            // These are filled by ReferenceFixer,
+            // they contain block IDs which must be mapped
             "RotorAzimuth",
             "RotorElevation",
             "CameraList",

--- a/MultigridProjectorClient/Utilities/UpdateBlock.cs
+++ b/MultigridProjectorClient/Utilities/UpdateBlock.cs
@@ -17,12 +17,6 @@ using SpaceEngineers.Game.EntityComponents.Blocks;
 using VRage.Sync;
 using Sandbox.Graphics.GUI;
 using MultigridProjector.Logic;
-using Sandbox.Common.ObjectBuilders;
-using Sandbox.Game.Entities;
-using Sandbox.Game.GameSystems;
-using Sandbox.Game.Screens.Helpers;
-using VRage.ObjectBuilders;
-using static MultigridProjectorClient.Extra.ConnectSubgrids;
 
 namespace MultigridProjectorClient.Utilities
 {
@@ -79,8 +73,7 @@ namespace MultigridProjectorClient.Utilities
                 projection.Projector?.EntityId != sourceProjection.Projector?.EntityId)
                 return;
 
-            if (!projection.ToolbarFixer.TryGetSelectedBlockIdsFromEventController(projection, previewBlock, out var selectedBlockIds))
-                return;
+            var selectedBlockIds = projection.MapPreviewToBuiltTerminalBlockIds(previewBlock.GetSelectedBlockIds()).ToList();
 
             // No need to select blocks if there were none selected (an empty list is the default)
             if (!selectedBlockIds.Any())
@@ -94,248 +87,65 @@ namespace MultigridProjectorClient.Utilities
         }
     }
 
-    internal static class UpdateToolbar
-    {
-        private const string UnknownText = "UNKNOWN ACTION";
-        private const string PlaceholderText = "ACTION ENTITY NOT FOUND";
-
-        private static MyToolbarItem CreateTerminalToolbarItem(MyObjectBuilder_ToolbarItemTerminalBlock builder, long? blockEntityId)
-        {
-            if (!MyEntities.TryGetEntityById(blockEntityId ?? builder.BlockEntityId, out MyTerminalBlock itemPreview))
-                return null;
-
-            MySlimBlock itemBuilt = Construction.GetBuiltBlock(itemPreview.SlimBlock);
-
-            if (itemBuilt?.FatBlock == null)
-                return null;
-
-            MyObjectBuilder_ToolbarItemTerminalBlock data = MyObjectBuilderSerializer.CreateNewObject<MyObjectBuilder_ToolbarItemTerminalBlock>();
-            data.BlockEntityId = itemBuilt.FatBlock.EntityId;
-            data._Action = builder._Action;
-            data.Parameters = builder.Parameters;
-
-            return MyToolbarItemFactory.CreateToolbarItem(data);
-        }
-
-        private static MyToolbarItem CreateGroupToolbarItem(MyObjectBuilder_ToolbarItemTerminalGroup builder, long blockEntityId)
-        {
-            MyObjectBuilder_ToolbarItemTerminalGroup data = MyObjectBuilderSerializer.CreateNewObject<MyObjectBuilder_ToolbarItemTerminalGroup>();
-            data.GroupName = builder.GroupName;
-            data._Action = builder._Action;
-            data.Parameters = builder.Parameters;
-
-            // This is used internally to find which grid the block group is on.
-            // It needs to be set to the block we want to assign the toolbar to.
-            data.BlockEntityId = blockEntityId;
-
-            return MyToolbarItemFactory.CreateToolbarItem(data);
-        }
-
-        private static MyToolbarItem CreateDummyToolbarItem(string text, long blockEntityId)
-        {
-            MyObjectBuilder_ToolbarItemTerminalGroup data = MyObjectBuilderSerializer.CreateNewObject<MyObjectBuilder_ToolbarItemTerminalGroup>();
-            data.GroupName = text;
-            data._Action = "";
-
-            // This is used internally to find which grid the block group is on.
-            // It needs to be set to the block we want to assign the toolbar to.
-            data.BlockEntityId = blockEntityId;
-
-            return MyToolbarItemFactory.CreateToolbarItem(data);
-        }
-
-        private static MyBlockGroup CreateDummyGroup(string name, MyTerminalBlock dummyBlock)
-        {
-            var dummyGroup = (MyBlockGroup)Activator.CreateInstance(typeof(MyBlockGroup), true);
-            dummyGroup.Name = new StringBuilder(name);
-            Reflection.SetValue(dummyGroup, "Blocks", new HashSet<MyTerminalBlock>
-            {
-                dummyBlock
-            });
-
-            var terminalSystem = dummyBlock.CubeGrid.GridSystems.TerminalSystem;
-            terminalSystem.AddUpdateGroup(dummyGroup, true);
-
-            return dummyGroup;
-        }
-
-        private static void RemoveDummyGroup(MyBlockGroup dummyGroup)
-        {
-            var dummyBlock = dummyGroup.GetTerminalBlocks().First();
-            var terminalSystem = dummyBlock.CubeGrid.GridSystems.TerminalSystem;
-            terminalSystem.RemoveGroup(dummyGroup, true);
-        }
-
-        private static void SetItemAtIndexWithDummyGroup(MyToolbar toolbar, int index, MyToolbarItem item, string name, MyTerminalBlock dummyBlock)
-        {
-            // Server side validation prevents toolbars from being made without a valid group
-            // We can sidestep this by making a group and removing it once the item is added
-            // TODO: Use an event rather then a fixed delay
-            var group = CreateDummyGroup(name, dummyBlock);
-            Events.InvokeOnGameThread(() => toolbar.SetItemAtIndex(index, item), 20);
-            Events.InvokeOnGameThread(() => RemoveDummyGroup(group), 40);
-        }
-
-        private static MyToolbar GetToolbar(MyTerminalBlock block)
-        {
-            if (block is MyTimerBlock timerBlock)
-                return timerBlock.Toolbar;
-
-            if (block is MySensorBlock sensorBlock)
-                return sensorBlock.Toolbar;
-
-            if (block is MyButtonPanel buttonPanel)
-                return buttonPanel.Toolbar;
-
-            if (block is MyEventControllerBlock eventControllerBlock)
-                return eventControllerBlock.Toolbar;
-
-            if (block is MyFlightMovementBlock flightMovementBlock)
-                return flightMovementBlock.Toolbar;
-
-            if (block is MyAirVent airVent)
-                return (MyToolbar)Reflection.GetValue(airVent, "m_actionToolbar");
-
-            // Cockpits, remote controls and cryopods
-            if (block is MyShipController shipController)
-                return shipController.Toolbar;
-
-            return null;
-        }
-
-        // FIXME: Use `ToolbarFixer` instead to restore toolbar slots from the preview
-        public static void CopyToolbars(MyTerminalBlock sourceBlock, MyTerminalBlock destinationBlock)
-        {
-            // FIXME: Awkward way to verify that the preview block corresponds to the built block.
-            // It would be much cleaner to pass only the block location of the event controller to restore
-            // the source blocks for from the corresponding projection (preview block).
-            if (!MultigridProjection.TryFindProjectionByProjector(sourceBlock.CubeGrid.Projector, out var sourceProjection) ||
-                !MultigridProjection.TryFindProjectionByBuiltGrid(destinationBlock.CubeGrid, out var projection, out _) ||
-                projection.Projector?.EntityId != sourceProjection.Projector?.EntityId)
-                return;
-
-            if (!TryGetSubgrid(sourceBlock.SlimBlock, out Subgrid subgrid))
-                return;
-
-
-            MyToolbar sourceToolbar = GetToolbar(sourceBlock);
-            MyToolbar destinationToolbar = GetToolbar(destinationBlock);
-
-            if (sourceToolbar == null || destinationToolbar == null)
-                return;
-
-            for (int i = 0; i < sourceToolbar.Items.Length; i++)
-            {
-                MyToolbarItem toolbarItem = sourceToolbar.GetItemAtIndex(i);
-                var fixedBuilder = projection.ToolbarFixer.GetBuilderAtIndex(projection, subgrid, sourceBlock, i);
-
-                if (toolbarItem == null)
-                    continue;
-
-                MyObjectBuilder_ToolbarItem builder = toolbarItem.GetObjectBuilder();
-                if (builder is MyObjectBuilder_ToolbarItemTerminalBlock terminalBuilder)
-                {
-                    long? blockEntityId;
-                    if (fixedBuilder != null)
-                        blockEntityId = ((MyObjectBuilder_ToolbarItemTerminalBlock)fixedBuilder).BlockEntityId;
-                    else
-                        blockEntityId = null;
-
-                    MyToolbarItem newToolbarItem = CreateTerminalToolbarItem(terminalBuilder, blockEntityId);
-
-                    // Make a placeholder if the entity the toolbar is attached to could not be found
-                    if (newToolbarItem == null)
-                    {
-                        newToolbarItem = CreateDummyToolbarItem(PlaceholderText, destinationBlock.EntityId);
-                        SetItemAtIndexWithDummyGroup(destinationToolbar, i, newToolbarItem, PlaceholderText, destinationBlock);
-                        continue;
-                    }
-
-                    destinationToolbar.SetItemAtIndex(i, newToolbarItem);
-                    continue;
-                }
-
-                if (builder is MyObjectBuilder_ToolbarItemTerminalGroup groupBuilder)
-                {
-                    bool groupExists = false;
-                    foreach (MyBlockGroup group in destinationBlock.CubeGrid.GetBlockGroups())
-                    {
-                        if (group.Name.ToString() == groupBuilder.GroupName)
-                            groupExists = true;
-                    }
-
-                    MyToolbarItem newToolbarItem = CreateGroupToolbarItem(groupBuilder, destinationBlock.EntityId);
-
-                    if (!groupExists)
-                    {
-                        SetItemAtIndexWithDummyGroup(destinationToolbar, i, newToolbarItem, groupBuilder.GroupName, destinationBlock);
-                        continue;
-                    }
-
-                    destinationToolbar.SetItemAtIndex(i, newToolbarItem);
-                    continue;
-                }
-
-                // If the toolbar item is of an unknown type make a dummy item as an error message
-                {
-                    MyToolbarItem newToolbarItem = CreateDummyToolbarItem(UnknownText, destinationBlock.EntityId);
-                    SetItemAtIndexWithDummyGroup(destinationToolbar, i, newToolbarItem, UnknownText, destinationBlock);
-
-                    PluginLog.Error($"Cannot process toolbar item: {toolbarItem}");
-                }
-            }
-        }
-    }
-
     internal static class UpdateBlock
     {
         // Allocate this only once
-        private static readonly HashSet<string> ExcludedEventControllerProperties = new HashSet<string>
+        private static readonly HashSet<string> ExcludedEventControllerPropertiesEventController = new HashSet<string>
         {
-            "SearchBox"
+            // UI only field, it would fail if set programmatically
+            "SearchBox",
+        };
+
+        private static readonly HashSet<string> ExcludedEventControllerPropertiesTurretController = new HashSet<string>
+        {
+            // These are filled by ReferenceFixer
+            "RotorAzimuth",
+            "RotorElevation",
+            "CameraList",
         };
 
         public static void CopyProperties(MyTerminalBlock sourceBlock, MyTerminalBlock destinationBlock)
         {
-            // Special case event controllers
-            if (sourceBlock is MyEventControllerBlock sourceEventControllerBlock &&
-                destinationBlock is MyEventControllerBlock destinationEventControllerBlock)
+            // Special cases
+            var powerDelay = -1;
+            HashSet<string> exclude = null;
+            switch (sourceBlock)
             {
-                // Copy over terminal properties
-                CopyTerminalProperties(sourceBlock, destinationBlock, ExcludedEventControllerProperties);
+                case MyEventControllerBlock _:
+                    exclude = ExcludedEventControllerPropertiesEventController;
+                    powerDelay = 120;
+                    break;
 
-                // Events in Event Controllers are not stored as properties, so copy those as well
-                UpdateEventController.CopyEvents(sourceEventControllerBlock, destinationEventControllerBlock);
-                UpdateToolbar.CopyToolbars(sourceBlock, destinationBlock);
-
-                // Copying power must be done in the next frame as disabling a block will prevent properties being modified
-                // so we need to wait for all the changes to process
-                Events.InvokeOnGameThread(() => CopyPowerState(sourceBlock, destinationBlock), 120);
-
-                return;
+                case MyTurretControlBlock _:
+                    exclude = ExcludedEventControllerPropertiesTurretController;
+                    powerDelay = 120;
+                    break;
             }
 
             // Copy over terminal properties
-            CopyTerminalProperties(sourceBlock, destinationBlock);
-            UpdateToolbar.CopyToolbars(sourceBlock, destinationBlock);
+            CopyTerminalProperties(sourceBlock, destinationBlock, exclude);
 
             // Copy over special properties if applicable
-            if (sourceBlock is MyProjectorBase sourceProjectorBase &&
-                destinationBlock is MyProjectorBase destinationProjectorBase)
+            switch (sourceBlock)
             {
-                CopyBlueprints(sourceProjectorBase, destinationProjectorBase);
-            }
+                case MyProjectorBase sourceProjectorBase when destinationBlock is MyProjectorBase destinationProjectorBase:
+                    CopyBlueprints(sourceProjectorBase, destinationProjectorBase);
+                    break;
 
-            else if (sourceBlock is IMyProgrammableBlock sourceProgrammableBlock &&
-                     destinationBlock is IMyProgrammableBlock destinationProgrammableBlock &&
-                     MySession.Static.IsSettingsExperimental())
-            {
-                CopyScripts(sourceProgrammableBlock, destinationProgrammableBlock);
+                case MyEventControllerBlock sourceEventControllerBlock when destinationBlock is MyEventControllerBlock destinationEventControllerBlock:
+                    // Events in Event Controllers are not stored as properties, so copy those as well
+                    UpdateEventController.CopyEvents(sourceEventControllerBlock, destinationEventControllerBlock);
+                    break;
+
+                case IMyProgrammableBlock sourceProgrammableBlock when destinationBlock is IMyProgrammableBlock destinationProgrammableBlock:
+                    if (MySession.Static.IsSettingsExperimental())
+                        CopyScripts(sourceProgrammableBlock, destinationProgrammableBlock);
+                    break;
             }
 
             // Copying power must be done in the next frame as disabling a block will prevent properties being modified
             // so we need to wait for all the changes to process
-            Events.InvokeOnGameThread(() => CopyPowerState(sourceBlock, destinationBlock));
+            Events.InvokeOnGameThread(() => CopyPowerState(sourceBlock, destinationBlock), powerDelay);
         }
 
         private static void CopyPowerState(MyTerminalBlock sourceBlock, MyTerminalBlock destinationBlock)
@@ -355,6 +165,7 @@ namespace MultigridProjectorClient.Utilities
                 PluginLog.Warn("CopyTerminalProperties(): sourceBlock is null");
                 return;
             }
+
             if (destinationBlock == null)
             {
                 PluginLog.Warn("CopyTerminalProperties(): destinationBlock is null");
@@ -371,11 +182,11 @@ namespace MultigridProjectorClient.Utilities
                     continue;
 
                 // Allow skipping properties for compatibility reasons
-                if (!(exclude is null) && exclude.Contains(property.Id))
+                if (exclude?.Contains(property.Id) == true)
                     continue;
 
                 string propertyType = property.TypeName;
-                
+
                 // Silencing a rare crash,
                 // see: https://discord.com/channels/1378756728107040829/1391879813006098463
                 try
@@ -403,7 +214,7 @@ namespace MultigridProjectorClient.Utilities
                             break;
                     }
                 }
-                catch(NullReferenceException e)
+                catch (NullReferenceException e)
                 {
                     PluginLog.Error(e, $"CopyTerminalProperties(): Silenced NullReferenceException: {property.TypeName} in {property.Id}");
                 }
@@ -420,7 +231,7 @@ namespace MultigridProjectorClient.Utilities
 
         private static void CopyBlueprints(MyProjectorBase sourceBlock, MyProjectorBase destinationBlock)
         {
-            var projectedGrids = (List<MyObjectBuilder_CubeGrid>) Reflection.GetValue(sourceBlock, "m_savedProjections");
+            var projectedGrids = (List<MyObjectBuilder_CubeGrid>)Reflection.GetValue(sourceBlock, "m_savedProjections");
             var initFromObjectBuilder = Reflection.GetMethod(typeof(MyProjectorBase), destinationBlock, "InitFromObjectBuilder");
 
             if (projectedGrids == null)


### PR DESCRIPTION
- Properly updating block references on building any kind of functional blocks and on fixing toolbars
- Fixed minor issues with client side only MGP in multiplayer, for example the enabled state is properly restored now
- Added error handling to log any unexpected errors caused by copying properties instead of causing a crash

Blueprint for testing: https://steamcommunity.com/sharedfiles/filedetails/?id=3404491177