### PR TITLE
Fixed alignment in Load Repair Projection

### DIFF
--- a/.run/Vanilla Space Engineers.run.xml
+++ b/.run/Vanilla Space Engineers.run.xml
@@ -9,7 +9,6 @@
     <option name="RUNTIME_ARGUMENTS" value="" />
     <option name="RUNTIME_TYPE" value="netfw" />
     <method v="2">
-      <option name="Build" default="false" projectName="MultigridProjectorClient" projectPath="$PROJECT_DIR$/MultigridProjectorClient/MultigridProjectorClient.csproj" />
       <option name="Build" default="false" projectName="IngameApiTest" projectPath="$PROJECT_DIR$/IngameApiTest/IngameApiTest.csproj" />
       <option name="Build" default="false" projectName="ModApiTest" projectPath="$PROJECT_DIR$/ModApiTest/ModApiTest.csproj" />
     </method>

--- a/MultigridProjector/Logic/FastBlockLocation.cs
+++ b/MultigridProjector/Logic/FastBlockLocation.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using VRageMath;
+
+namespace MultigridProjector.Logic
+{
+    // IEquatable is implemented to avoid boxing on comparison
+    public readonly struct FastBlockLocation : IEquatable<FastBlockLocation>
+    {
+        public readonly int GridIndex;
+        public readonly Vector3I Position;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public FastBlockLocation(int gridIndex, Vector3I position)
+        {
+            // Subgrid index
+            GridIndex = gridIndex;
+
+            // Block position inside the subgrid in blueprint block coordinates
+            Position = position;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public override int GetHashCode()
+        {
+            return ((GridIndex * 397 ^ Position.X) * 397 ^ Position.Y) * 397 ^ Position.Z;
+        }
+            
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Equals(FastBlockLocation other)
+        {
+            return GridIndex == other.GridIndex && Position.Equals(other.Position);
+        }
+            
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public override bool Equals(object obj)
+        {
+            return obj is FastBlockLocation other && Equals(other);
+        }
+    }
+}

--- a/MultigridProjector/Logic/MultigridProjection.cs
+++ b/MultigridProjector/Logic/MultigridProjection.cs
@@ -1923,7 +1923,7 @@ System.NullReferenceException: Object reference not set to an instance of an obj
                 firstGridBuilder.CubeBlocks.First() is MyObjectBuilder_Projector projectorBuilder)
             {
                 // The blueprint is aligned to a repair projector therefore no offset is required
-                var projectorInterface = (IMyProjector) projector;
+                IMyProjector projectorInterface = projector;
                 projectorInterface.ProjectionOffset = Vector3I.Zero;
 
                 // Cancel out the projector's block orientation in the blueprint, so the projector you

--- a/MultigridProjector/MultigridProjector.projitems
+++ b/MultigridProjector/MultigridProjector.projitems
@@ -14,6 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Logic\ProjectedBlock.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Logic\BlockMinLocation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Logic\MultigridProjectorApiProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Logic\FastBlockLocation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Logic\ToolbarFixer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Logic\VisualState.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Patches\MyCubeGrid_TestPlacementAreaCube.cs" />

--- a/multigrid-projector.sln.DotSettings
+++ b/multigrid-projector.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=PO/@EntryIndexedValue">PO</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Comms/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cryopods/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=desync/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
- Fixed alignment in Load Repair Projection if the projector is not named "Repair", but otherwise unique
- Not building the client plugin before starting the vanilla game
- Introduced `FastBlockLocation` for reuse in future code