### PR TITLE
Fix ProjectorAligner

### DIFF
--- a/MultigridProjectorClient/Extra/ProjectorAligner.cs
+++ b/MultigridProjectorClient/Extra/ProjectorAligner.cs
@@ -200,6 +200,8 @@ namespace MultigridProjectorClient.Extra
                 }
 
                 MyStringId rotationControl = RotationControls[directionIndex];
+                MyInput.Static.SetEnabledOnControl(rotationControl, enabled: true);
+
                 if (MyControllerHelper.IsControl(MyStringId.NullOrEmpty, rotationControl, MyControlStateType.NEW_PRESSED_REPEATING))
                 {
                     Rotate(directionIndex);


### PR DESCRIPTION
This PR fixes a timing issue caused by the SE update `1.206.028`, when `MyCubeBuilder.DeactivateRotationControls` was added.